### PR TITLE
Stable Diffusion-3.5-Medium Functional

### DIFF
--- a/models/experimental/tt_dit/README.md
+++ b/models/experimental/tt_dit/README.md
@@ -7,6 +7,7 @@ This directory contains the implementation of the Tenstorrent Diffusion Transfor
 For detailed information about each model including performance metrics, usage instructions, and specific requirements, see:
 
 - **[Stable Diffusion 3.5 Large](models/StableDiffusion35.md)** - Text-to-image generation
+- **[Stable Diffusion 3.5 Medium](models/StableDiffusionMed35.md)** - Text-to-image generation
 - **[Flux 1](models/Flux1.md)** - Text-to-image generation (schnell & dev variants)
 - **[Motif](models/Motif.md)** - Text-to-image generation model
 - **[Qwen-Image](models/QwenImage.md)** - Text-to-image generation model
@@ -19,9 +20,10 @@ For detailed information about each model including performance metrics, usage i
 tt_dit/
 ├── layers/              # Core neural network layers
 ├── models/              # Model architectures and documentation
-│   ├── transformers/    # Transformer implementations (SD35, Mochi, Wan, Flux1, Motif, QwenImage)
+│   ├── transformers/    # Transformer implementations (SD35, SD35 medium, Mochi, Wan, Flux1, Motif)
 │   ├── vae/            # VAE/Autoencoder implementations
 │   ├── StableDiffusion35.md  # SD3.5 model documentation
+│   ├── StableDiffusionMed35.md  # SD3.5 medium model documentation
 │   ├── Flux1.md         # Flux 1 model documentation
 │   ├── Motif.md         # Motif model documentation
 │   ├── QwenImage.md     # Qwen-Image model documentation
@@ -41,7 +43,7 @@ tt_dit/
 │   ├── motif/
 │   └── qwenimage/
 ├── tests/              # Test suite
-│   ├── models/         # Model-level tests (sd35, mochi, wan2_2, flux1, motif, qwenimage)
+│   ├── models/         # Model-level tests (sd35, sd35 medium, mochi, wan2_2, flux1, motif)
 │   ├── encoders/       # Encoder tests
 │   ├── blocks/         # Block-level tests
 │   └── unit/          # Unit tests for layers
@@ -62,7 +64,7 @@ tt_dit/
 
 ### Models
 - **Transformers**: DiT transformer implementations for various generative models
-  - Support for multiple architectures including SD3.5, Mochi, Wan2.2, Flux1, Motif, and Qwen-Image
+  - Support for multiple architectures including SD3.5, SD3.5 medium, Mochi, Wan2.2, Flux1, and Motif
   - Model-specific attention mechanisms and transformer architectures
 - **Autoencoders**: VAE implementations for different models
 
@@ -73,6 +75,7 @@ tt_dit/
 ### Pipelines
 End-to-end pipeline implementations for multiple generative models:
 - **Stable Diffusion 3.5 Large**: Text-to-image generation (1024x1024px)
+- **Stable Diffusion 3.5 Medium**: Text-to-image generation (512x512px)
 - **Flux 1**: Text-to-image generation (schnell & dev variants, 1024x1024px)
 - **Motif**: Text-to-image generation (6B model, 1024x1024px)
 - **Qwen-Image**: Text-to-image generation (1024x1024px)
@@ -108,6 +111,7 @@ python -m pytest tests/models/
 
 # Run specific model pipeline tests
 python -m pytest tests/models/sd35/test_pipeline_sd35.py -v
+python -m pytest tests/models/sd35_med/test_pipeline_sd35_medium.py -v
 python -m pytest tests/models/flux1/test_pipeline_flux1.py -v
 python -m pytest tests/models/motif/test_pipeline_motif.py -v
 python -m pytest tests/models/qwenimage/test_pipeline_qwenimage.py -v

--- a/models/experimental/tt_dit/README.md
+++ b/models/experimental/tt_dit/README.md
@@ -20,7 +20,7 @@ For detailed information about each model including performance metrics, usage i
 tt_dit/
 ├── layers/              # Core neural network layers
 ├── models/              # Model architectures and documentation
-│   ├── transformers/    # Transformer implementations (SD35, SD35 medium, Mochi, Wan, Flux1, Motif)
+│   ├── transformers/    # Transformer implementations (SD35, SD35 medium, Mochi, Wan, Flux1, Motif, QwenImage)
 │   ├── vae/            # VAE/Autoencoder implementations
 │   ├── StableDiffusion35.md  # SD3.5 model documentation
 │   ├── StableDiffusionMed35.md  # SD3.5 medium model documentation
@@ -43,7 +43,7 @@ tt_dit/
 │   ├── motif/
 │   └── qwenimage/
 ├── tests/              # Test suite
-│   ├── models/         # Model-level tests (sd35, sd35 medium, mochi, wan2_2, flux1, motif)
+│   ├── models/         # Model-level tests (sd35, sd35 medium, mochi, wan2_2, flux1, motif, qwenimage)
 │   ├── encoders/       # Encoder tests
 │   ├── blocks/         # Block-level tests
 │   └── unit/          # Unit tests for layers

--- a/models/experimental/tt_dit/layers/conv2d.py
+++ b/models/experimental/tt_dit/layers/conv2d.py
@@ -268,12 +268,15 @@ class Conv2d(Module):
                 msg = f"expected input channel dimension to be {expected_c}, but got {c}"
                 raise ValueError(msg)
 
-        slice_config = ttnn.Conv2dSliceConfig(
-            num_slices=self.slice_params.get(tuple(self.mesh_device.shape), self.slice_default)[
-                (h, w, self.in_channels, self.out_channels)
-            ],
-            slice_type=ttnn.Conv2dDRAMSliceWidth,
-        )
+        try:
+            slice_config = ttnn.Conv2dSliceConfig(
+                num_slices=self.slice_params.get(tuple(self.mesh_device.shape), self.slice_default)[
+                    (h, w, self.in_channels, self.out_channels)
+                ],
+                slice_type=ttnn.Conv2dDRAMSliceWidth,
+            )
+        except:
+            slice_config = None
 
         try:
             x, [out_height, out_width] = ttnn.conv2d(

--- a/models/experimental/tt_dit/layers/conv2d.py
+++ b/models/experimental/tt_dit/layers/conv2d.py
@@ -268,15 +268,12 @@ class Conv2d(Module):
                 msg = f"expected input channel dimension to be {expected_c}, but got {c}"
                 raise ValueError(msg)
 
-        try:
-            slice_config = ttnn.Conv2dSliceConfig(
-                num_slices=self.slice_params.get(tuple(self.mesh_device.shape), self.slice_default)[
-                    (h, w, self.in_channels, self.out_channels)
-                ],
-                slice_type=ttnn.Conv2dDRAMSliceWidth,
-            )
-        except:
-            slice_config = None
+        slice_config = ttnn.Conv2dSliceConfig(
+            num_slices=self.slice_params.get(tuple(self.mesh_device.shape), self.slice_default)[
+                (h, w, self.in_channels, self.out_channels)
+            ],
+            slice_type=ttnn.Conv2dDRAMSliceWidth,
+        )
 
         try:
             x, [out_height, out_width] = ttnn.conv2d(

--- a/models/experimental/tt_dit/models/StableDiffusionMed35.md
+++ b/models/experimental/tt_dit/models/StableDiffusionMed35.md
@@ -1,0 +1,44 @@
+# Stable Diffusion 3.5 Medium
+
+## Introduction
+
+[Stable Diffusion 3.5 Medium](https://stability.ai/news/introducing-stable-diffusion-3-5) is a generative model for text-guided image synthesis.
+The Medium version is a lighter and faster variant of SD3.5, tuned for performance on Wormhole systems using TT-Metal.
+
+## Details
+
+The architecture follows the paper
+[Scaling Rectified Flow Transformers for High-Resolution Image Synthesis](https://arxiv.org/abs/2403.03206).
+
+The model consists of a single text encoder with its tokenizer, a scheduler, a compact MMDiT transformer and a VAE.
+The MMDiT is built from spatial, prompt and time embeddings together with a stack of transformer blocks.
+Attention layers operate either on the spatial embedding alone or jointly on the spatial and prompt embeddings.
+
+Compared to SD3.5-Large, the Medium variant is smaller, faster, and requires less memory while preserving the same core architecture.
+
+## Performance
+
+Performance is measured in seconds per 1024×1024 image.
+
+| System    | CFG | SP | TP | Current Performance | Target Performance |
+|-----------|-----|----|----|---------------------|--------------------|
+| QuietBox  | _   | _  | _  | ~_._s               | ~_._s              |
+| Galaxy    | _   | _  | _  | ~_._s               | ~_._s              |
+
+
+## Prerequisites
+
+- Clone the [tt-metal repository](https://github.com/tenstorrent/tt-metal)
+- Install TT-Metalium™ / TT-NN™
+  → https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md
+- Request access to SD3.5-Medium on HuggingFace
+
+## How to Run
+
+1. Visit the model page on HuggingFace:
+   https://huggingface.co/stabilityai/stable-diffusion-3.5-medium
+
+2. Login using HuggingFace token:
+
+```bash
+huggingface-cli login

--- a/models/experimental/tt_dit/models/StableDiffusionMed35.md
+++ b/models/experimental/tt_dit/models/StableDiffusionMed35.md
@@ -3,20 +3,21 @@
 ## Introduction
 
 [Stable Diffusion 3.5 Medium](https://stability.ai/news/introducing-stable-diffusion-3-5) is a generative model for text-guided image synthesis.
-The Medium version is a lighter and faster variant of SD3.5, tuned for performance on Wormhole systems using TT-Metal.
+The Medium version is a lighter and faster variant of SD3.5, optimized for performance on Wormhole systems using TT-Metal.
 
 ## Details
 
 The architecture follows the paper
 [Scaling Rectified Flow Transformers for High-Resolution Image Synthesis](https://arxiv.org/abs/2403.03206).
 
-The model consists of a single text encoder with its tokenizer, a scheduler, a compact MMDiT transformer and a VAE.
-The MMDiT is built from spatial, prompt and time embeddings together with a stack of transformer blocks.
+The model consists of CLIP text encoders with their tokenizers, an optional T5 text encoder, a scheduler, a compact MMDiT transformer and a VAE decoder.
+The MMDiT transformer is built from spatial, prompt and time embeddings together with a stack of 24 transformer blocks.
 Attention layers operate either on the spatial embedding alone or jointly on the spatial and prompt embeddings.
 
 Compared to SD3.5-Large, the Medium variant is smaller, faster, and requires less memory while preserving the same core architecture.
 
 ## Performance
+
 Measured on N300 (1x2 mesh) at 512×512 with 40 steps:
 
 - prompt encoding: ~52.81s
@@ -26,9 +27,6 @@ Measured on N300 (1x2 mesh) at 512×512 with 40 steps:
 
 ## Prerequisites
 
-- Clone the [tt-metal repository](https://github.com/tenstorrent/tt-metal)
-- Install TT-Metalium™ / TT-NN™
-  → https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md
 - Request access to SD3.5-Medium on HuggingFace
 
 ## How to Run
@@ -49,8 +47,105 @@ source python_env/bin/activate
 export PYTHONPATH=$(pwd)
 ```
 
-4. Run the SD3.5 Medium pipeline module:
+4. Run the SD3.5 Medium pipeline test:
 
 ```bash
-python -m models.experimental.tt_dit.pipelines.stable_diffusion_35_medium.pipeline_stable_diffusion_35_medium
+# Run on N150 (1x1 mesh) at 512x512
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x1_n150 and 512x512"
+
+# Run on N300 (1x2 mesh) at 512x512
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x2_n300 and 512x512"
+
+# Run on N300 (1x2 mesh) at 1024x1024
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x2_n300 and 1024x1024"
 ```
+
+5. (Optional) Provide custom prompts via command line arguments or environment variables:
+
+```bash
+# Using command line arguments
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py --prompt "your custom prompt" --negative-prompt "your negative prompt"
+
+# Using environment variables
+PROMPT="your custom prompt" NEGATIVE_PROMPT="your negative prompt" pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+```
+
+## Performance Testing
+
+The SD3.5 Medium pipeline includes a comprehensive performance test suite that measures and reports detailed timing metrics for all pipeline stages.
+
+### Running Performance Tests
+
+```bash
+# Run performance test on N150 (1x1 mesh) at 512x512
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x1_n150 and 512x512"
+
+# Run performance test on N300 (1x2 mesh) at 512x512
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x2_n300 and 512x512"
+
+# Run performance test on N300 (1x2 mesh) at 1024x1024
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x2_n300 and 1024x1024"
+```
+
+### Performance Test Features
+
+The performance test suite provides:
+
+- **Warmup Run**: Initial run to warm up the pipeline and devices
+- **Multiple Iterations**: 4 performance measurement runs with different prompts
+- **Detailed Timing Breakdown**:
+  - CLIP encoding time
+  - T5 encoding time (if enabled)
+  - Total encoding time
+  - Individual denoising step times
+  - VAE decoding time
+  - Total pipeline runtime
+- **Statistical Analysis**: Mean, standard deviation, min, and max for all timing metrics
+- **Throughput Metrics**: Steps per second and images per second
+- **Performance Benchmarks**: Automatic performance analysis with thresholds
+- **CI Integration**: Benchmark data collection for continuous performance monitoring
+
+### Performance Test Output
+
+The test generates:
+- **Console Output**: Detailed performance report with statistics and analysis
+- **Image Files**: Generated images saved as `sd35_medium_{width}x{height}_warmup.png` and `sd35_medium_{width}x{height}_perf_run{N}.png`
+- **Benchmark Data**: JSON files for CI integration (when running in CI environment)
+
+### Performance Test Configurations
+
+The performance test runs with the following configurations:
+- **Mesh Configurations**: N150 (1x1) and N300 (1x2)
+- **Image Sizes**: 512×512 and 1024×1024
+- **Fabric Configurations**: DISABLED and FABRIC_1D (FABRIC_1D skipped for single-device configurations)
+- **Inference Steps**: 40 steps
+- **Guidance Scale**: 7.0
+
+Note: The test automatically skips FABRIC_1D configuration for single-device (1x1) mesh setups, as fabric requires multiple devices.
+
+## Scalability
+
+SD3.5-Medium has been implemented to support execution on:
+- **N150** (1x1 mesh): Single device configuration without CFG parallelism
+- **N300** (1x2 mesh): Two devices with CFG parallelism
+
+The model has been tested on Wormhole systems.
+
+The DiT model can be parallelized on the following axes:
+1. **CFG (classifier-free guidance)**: Execute conditional and unconditional steps in parallel (factor 2 on N300)
+2. **SP (sequence parallel)**: The input sequence is fractured across a mesh axis (not currently used in Medium)
+3. **TP (tensor parallel)**: Weights are fractured across a mesh axis (not currently used in Medium)
+
+The text embedding models (CLIP encoders) and the VAE decoder are parallelized with tensor parallelism when multiple devices are available.
+
+## Architecture Details
+
+- **Transformer**: 24 transformer blocks with 1536 hidden dimensions and 24 attention heads
+- **Text Encoders**: CLIP text encoders (required) and optional T5 text encoder
+- **VAE Decoder**: Fully implemented in TTNN for efficient decoding
+- **Image Sizes**: Supports 512×512 and 1024×1024 output resolutions
+- **Inference Steps**: Configurable (default: 40 steps)
+
+## Output
+
+Generated images are saved as `sd35_medium_tt_output_{width}x{height}.png` in the current working directory.

--- a/models/experimental/tt_dit/models/StableDiffusionMed35.md
+++ b/models/experimental/tt_dit/models/StableDiffusionMed35.md
@@ -18,12 +18,53 @@ Compared to SD3.5-Large, the Medium variant is smaller, faster, and requires les
 
 ## Performance
 
-Measured on N300 (1x2 mesh) at 512×512 with 40 steps:
+Performance measurements from the performance test suite:
 
-- prompt encoding: ~52.81s
-- denoising: ~105.66s
-- image decoding: ~87.32s
-- total runtime: ~246.71s
+### N150 (1x1 mesh) - 512×512, 40 steps, Guidance Scale=7.0
+
+- CLIP encoding: ~0.07s
+- T5 encoding: ~0.00s (disabled)
+- Total encoding: ~0.15s
+- Denoising (per step): ~0.60s
+- Total denoising: ~24.12s
+- VAE decoding: ~0.34s
+- **Total pipeline runtime: ~24.63s**
+- Throughput: ~0.0406 images/second
+
+### N150 (1x1 mesh) - 1024×1024, 40 steps, Guidance Scale=7.0
+
+- CLIP encoding: ~0.06s
+- T5 encoding: ~0.00s (disabled)
+- Total encoding: ~0.14s
+- Denoising (per step): ~2.63s
+- Total denoising: ~105.23s
+- VAE decoding: ~7.86s
+- **Total pipeline runtime: ~113.27s**
+- Throughput: ~0.0088 images/second
+
+### N300 (1x2 mesh) - 512×512, 40 steps, Guidance Scale=7.0
+
+- CLIP encoding: ~0.07s
+- T5 encoding: ~0.00s (disabled)
+- Total encoding: ~0.15s
+- Denoising (per step): ~0.71s
+- Total denoising: ~28.31s
+- VAE decoding: ~0.34s
+- **Total pipeline runtime: ~28.83s**
+- Throughput: ~0.0347 images/second
+
+### N300 (1x2 mesh) - 1024×1024, 40 steps, Guidance Scale=7.0
+
+- CLIP encoding: ~0.07s
+- T5 encoding: ~0.00s (disabled)
+- Total encoding: ~0.15s
+- Denoising (per step): ~2.68s
+- Total denoising: ~107.27s
+- VAE decoding: ~8.06s
+- **Total pipeline runtime: ~115.52s**
+- Throughput: ~0.0087 images/second
+
+*Note: Performance numbers are measured averages across multiple runs. Actual performance may vary based on system configuration and workload.*
 
 ## Prerequisites
 
@@ -53,6 +94,9 @@ export PYTHONPATH=$(pwd)
 # Run on N150 (1x1 mesh) at 512x512
 pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x1_n150 and 512x512"
 
+# Run on N150 (1x1 mesh) at 1024x1024
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x1_n150 and 1024x1024"
+
 # Run on N300 (1x2 mesh) at 512x512
 pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x2_n300 and 512x512"
 
@@ -78,13 +122,16 @@ The SD3.5 Medium pipeline includes a comprehensive performance test suite that m
 
 ```bash
 # Run performance test on N150 (1x1 mesh) at 512x512
-pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x1_n150 and 512x512"
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x1_n150 and 512"
+
+# Run performance test on N150 (1x1 mesh) at 1024x1024
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x1_n150 and 1024"
 
 # Run performance test on N300 (1x2 mesh) at 512x512
-pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x2_n300 and 512x512"
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x2_n300 and 512"
 
 # Run performance test on N300 (1x2 mesh) at 1024x1024
-pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x2_n300 and 1024x1024"
+pytest models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py -k "1x2_n300 and 1024"
 ```
 
 ### Performance Test Features

--- a/models/experimental/tt_dit/models/StableDiffusionMed35.md
+++ b/models/experimental/tt_dit/models/StableDiffusionMed35.md
@@ -17,14 +17,12 @@ Attention layers operate either on the spatial embedding alone or jointly on the
 Compared to SD3.5-Large, the Medium variant is smaller, faster, and requires less memory while preserving the same core architecture.
 
 ## Performance
+Measured on N300 (1x2 mesh) at 512×512 with 40 steps:
 
-Performance is measured in seconds per 1024×1024 image.
-
-| System    | CFG | SP | TP | Current Performance | Target Performance |
-|-----------|-----|----|----|---------------------|--------------------|
-| QuietBox  | _   | _  | _  | ~_._s               | ~_._s              |
-| Galaxy    | _   | _  | _  | ~_._s               | ~_._s              |
-
+- prompt encoding: ~52.81s
+- denoising: ~105.66s
+- image decoding: ~87.32s
+- total runtime: ~246.71s
 
 ## Prerequisites
 
@@ -35,10 +33,24 @@ Performance is measured in seconds per 1024×1024 image.
 
 ## How to Run
 
-1. Visit the model page on HuggingFace:
+1. Request access to the model on HuggingFace (required for gated weights):
    https://huggingface.co/stabilityai/stable-diffusion-3.5-medium
 
-2. Login using HuggingFace token:
+2. Authenticate with your HuggingFace token:
 
 ```bash
 huggingface-cli login
+```
+
+3. Activate the repo virtual environment and set `PYTHONPATH`:
+
+```bash
+source python_env/bin/activate
+export PYTHONPATH=$(pwd)
+```
+
+4. Run the SD3.5 Medium pipeline module:
+
+```bash
+python -m models.experimental.tt_dit.pipelines.stable_diffusion_35_medium.pipeline_stable_diffusion_35_medium
+```

--- a/models/experimental/tt_dit/models/transformers/sd35_med/attention_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/attention_sd35_medium.py
@@ -1,10 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-
-"""
-SD3.5 Medium Self-Attention Implementation
-Modified to support separate Q/K/V projections and added context.
-"""
 
 import ttnn
 from models.experimental.tt_dit.layers.linear import Linear
@@ -46,14 +41,13 @@ class SD35MediumSelfAttention:
         self.add_q_proj = Linear(self.added_proj_dim, dim, bias=qkv_bias, mesh_device=mesh_device)
         self.add_k_proj = Linear(self.added_proj_dim, dim, bias=qkv_bias, mesh_device=mesh_device)
         self.add_v_proj = Linear(self.added_proj_dim, dim, bias=qkv_bias, mesh_device=mesh_device)
-        # to_add_out only needed when context_pre_only=False
         if not context_pre_only:
             self.to_add_out = Linear(dim, self.added_proj_dim, mesh_device=mesh_device)
 
-        # Output projection - dropout handled in forward pass for inference
+        # Output projection
         if not pre_only:
             self.to_out = Linear(self.inner_dim, dim, mesh_device=mesh_device)
-            self.dropout_prob = 0.0  # Store dropout probability
+            self.dropout_prob = 0.0
 
         # QK normalization for main attention
         if qk_norm == "rms":
@@ -119,17 +113,17 @@ class SD35MediumSelfAttention:
         """
         B = x.shape[1]
 
-        # Main attention projections
-        q = self.to_q(x)  # [1, B, seq_len, dim]
+        # Main attention
+        q = self.to_q(x)
         k = self.to_k(x)
         v = self.to_v(x)
 
-        # Reshape to [B, seq_len, num_heads, head_dim] BEFORE applying RMSNorm
+        # Reshape to [B, seq_len, num_heads, head_dim]
         q = ttnn.reshape(q, (B, seq_len, self.num_heads, self.head_dim))
         k = ttnn.reshape(k, (B, seq_len, self.num_heads, self.head_dim))
         v = ttnn.reshape(v, (B, seq_len, self.num_heads, self.head_dim))
 
-        # Apply RMSNorm to Q and K AFTER reshaping (now head_dim=64 matches norm)
+        # Apply RMSNorm to Q and K
         if self.norm_q is not None:
             q = self.norm_q(q)
             k = self.norm_k(k)
@@ -139,14 +133,14 @@ class SD35MediumSelfAttention:
         k = ttnn.permute(k, (0, 2, 1, 3))
         v = ttnn.permute(v, (0, 2, 1, 3))
 
-        # SDPA program config
+        # Program config
         program_config = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=self.core_grid,
             q_chunk_size=64,
             k_chunk_size=64,
         )
 
-        # Handle added context if provided - SD3 uses JOINT attention (concatenate, attend, split)
+        # Handle added context if provided
         if added_input is not None:
             added_B = added_input.shape[1]
 
@@ -155,12 +149,12 @@ class SD35MediumSelfAttention:
             added_k = self.add_k_proj(added_input)
             added_v = self.add_v_proj(added_input)
 
-            # Reshape added tensors to [B, added_seq_len, num_heads, head_dim] BEFORE applying RMSNorm
+            # Reshape added tensors to [B, added_seq_len, num_heads, head_dim]
             added_q = ttnn.reshape(added_q, (added_B, added_seq_len, self.num_heads, self.head_dim))
             added_k = ttnn.reshape(added_k, (added_B, added_seq_len, self.num_heads, self.head_dim))
             added_v = ttnn.reshape(added_v, (added_B, added_seq_len, self.num_heads, self.head_dim))
 
-            # Apply RMSNorm to added Q and K AFTER reshaping (now head_dim=64 matches norm)
+            # Apply RMSNorm to added Q and K
             if self.norm_added_q is not None:
                 added_q = self.norm_added_q(added_q)
                 added_k = self.norm_added_k(added_k)
@@ -170,14 +164,11 @@ class SD35MediumSelfAttention:
             added_k = ttnn.permute(added_k, (0, 2, 1, 3))
             added_v = ttnn.permute(added_v, (0, 2, 1, 3))
 
-            # JOINT ATTENTION: Concatenate x and context along sequence dimension
-            # q: [B, num_heads, seq_len, head_dim], added_q: [B, num_heads, added_seq_len, head_dim]
-            # Result: [B, num_heads, seq_len + added_seq_len, head_dim]
             q_full = ttnn.concat([q, added_q], dim=2)
             k_full = ttnn.concat([k, added_k], dim=2)
             v_full = ttnn.concat([v, added_v], dim=2)
 
-            # Run unified self-attention on concatenated sequence
+            # Run self-attention on concatenated sequence
             attn_out_full = ttnn.transformer.scaled_dot_product_attention(
                 q_full,
                 k_full,
@@ -187,19 +178,16 @@ class SD35MediumSelfAttention:
                 program_config=program_config,
                 compute_kernel_config=self.compute_kernel_config,
             )
-            # Output shape: [B, num_heads, seq_len + added_seq_len, head_dim]
 
-            # Split output back into x and context parts
-            # attn_out: [B, num_heads, seq_len, head_dim]
-            # added_attn_out: [B, num_heads, added_seq_len, head_dim]
+            # Split output
             attn_out = attn_out_full[:, :, :seq_len, :]
             added_attn_out = attn_out_full[:, :, seq_len:, :]
 
-            # Transpose back: [B, num_heads, seq_len, head_dim] -> [B, seq_len, num_heads, head_dim]
+            # Transpose back
             attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))
             added_attn_out = ttnn.permute(added_attn_out, (0, 2, 1, 3))
 
-            # Reshape to [1, B, seq_len, inner_dim]
+            # Reshape
             attn_out = ttnn.reshape(attn_out, (1, B, seq_len, self.inner_dim))
             added_attn_out = ttnn.reshape(added_attn_out, (1, added_B, added_seq_len, self.inner_dim))
 
@@ -211,13 +199,13 @@ class SD35MediumSelfAttention:
                         attn_out, probability=self.dropout_prob, scale=1.0 / (1.0 - self.dropout_prob)
                     )
 
-            # Project added attention output back to added dimension (skip for final block)
+            # Project added attention output back to added dimension
             if not self.context_pre_only:
                 added_attn_out = self.to_add_out(added_attn_out)
 
             return attn_out, added_attn_out
 
-        # No added input - just self-attention on x
+        # self-attention on x
         attn_out = ttnn.transformer.scaled_dot_product_attention(
             q,
             k,
@@ -228,10 +216,10 @@ class SD35MediumSelfAttention:
             compute_kernel_config=self.compute_kernel_config,
         )
 
-        # Transpose back: [B, num_heads, seq_len, head_dim] -> [B, seq_len, num_heads, head_dim]
+        # Transpose back
         attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))
 
-        # Reshape to [1, B, seq_len, inner_dim]
+        # Reshape
         attn_out = ttnn.reshape(attn_out, (1, B, seq_len, self.inner_dim))
 
         # Output projection
@@ -251,13 +239,12 @@ class SD35MediumSelfAttention:
         self.to_k.load_torch_state_dict(substate(state_dict, "to_k"))
         self.to_v.load_torch_state_dict(substate(state_dict, "to_v"))
 
-        # Load added context weights (only if present - attn2 doesn't have these)
+        # Load added context weights
         add_q_state = substate(state_dict, "add_q_proj")
         if add_q_state:
             self.add_q_proj.load_torch_state_dict(add_q_state)
             self.add_k_proj.load_torch_state_dict(substate(state_dict, "add_k_proj"))
             self.add_v_proj.load_torch_state_dict(substate(state_dict, "add_v_proj"))
-            # to_add_out only exists in early/middle blocks, not final block
             if not self.context_pre_only:
                 to_add_out_state = substate(state_dict, "to_add_out")
                 if to_add_out_state:
@@ -271,7 +258,7 @@ class SD35MediumSelfAttention:
         if self.norm_q is not None:
             self.norm_q.load_torch_state_dict(substate(state_dict, "norm_q"))
             self.norm_k.load_torch_state_dict(substate(state_dict, "norm_k"))
-            # Only load added norm weights if present (attn2 doesn't have these)
+            # Only load added norm weights if present
             norm_added_q_state = substate(state_dict, "norm_added_q")
             if norm_added_q_state:
                 self.norm_added_q.load_torch_state_dict(norm_added_q_state)

--- a/models/experimental/tt_dit/models/transformers/sd35_med/attention_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/attention_sd35_medium.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SD3.5 Medium Self-Attention Implementation
+Modified to support separate Q/K/V projections and added context.
+"""
+
+import ttnn
+from models.experimental.tt_dit.layers.linear import Linear
+from models.experimental.tt_dit.layers.normalization import RMSNorm
+from models.experimental.tt_dit.utils.substate import substate
+
+
+class SD35MediumSelfAttention:
+    """Self-attention for SD3.5 Medium with added context support."""
+
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        qkv_bias=True,
+        pre_only=False,
+        qk_norm="rms",
+        eps=1e-6,
+        mesh_device=None,
+        added_proj_dim=None,
+        context_pre_only=False,
+    ):
+        self.dim = dim
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.pre_only = pre_only
+        self.context_pre_only = context_pre_only
+        self.inner_dim = num_heads * self.head_dim
+        self.scale = self.head_dim**-0.5
+        self.mesh_device = mesh_device
+        self.added_proj_dim = added_proj_dim or dim
+
+        # Separate Q, K, V projections
+        self.to_q = Linear(dim, dim, bias=qkv_bias, mesh_device=mesh_device)
+        self.to_k = Linear(dim, dim, bias=qkv_bias, mesh_device=mesh_device)
+        self.to_v = Linear(dim, dim, bias=qkv_bias, mesh_device=mesh_device)
+
+        # Additional projections for added context
+        self.add_q_proj = Linear(self.added_proj_dim, dim, bias=qkv_bias, mesh_device=mesh_device)
+        self.add_k_proj = Linear(self.added_proj_dim, dim, bias=qkv_bias, mesh_device=mesh_device)
+        self.add_v_proj = Linear(self.added_proj_dim, dim, bias=qkv_bias, mesh_device=mesh_device)
+        # to_add_out only needed when context_pre_only=False
+        if not context_pre_only:
+            self.to_add_out = Linear(dim, self.added_proj_dim, mesh_device=mesh_device)
+
+        # Output projection - dropout handled in forward pass for inference
+        if not pre_only:
+            self.to_out = Linear(self.inner_dim, dim, mesh_device=mesh_device)
+            self.dropout_prob = 0.0  # Store dropout probability
+
+        # QK normalization for main attention
+        if qk_norm == "rms":
+            self.norm_q = RMSNorm(
+                embedding_dim=self.head_dim,
+                norm_eps=eps,
+                norm_elementwise_affine=True,
+                bias=False,
+                mesh_device=mesh_device,
+            )
+            self.norm_k = RMSNorm(
+                embedding_dim=self.head_dim,
+                norm_eps=eps,
+                norm_elementwise_affine=True,
+                bias=False,
+                mesh_device=mesh_device,
+            )
+        else:
+            self.norm_q = None
+            self.norm_k = None
+
+        # QK normalization for added attention
+        if qk_norm == "rms":
+            self.norm_added_q = RMSNorm(
+                embedding_dim=self.head_dim,
+                norm_eps=eps,
+                norm_elementwise_affine=True,
+                bias=False,
+                mesh_device=mesh_device,
+            )
+            self.norm_added_k = RMSNorm(
+                embedding_dim=self.head_dim,
+                norm_eps=eps,
+                norm_elementwise_affine=True,
+                bias=False,
+                mesh_device=mesh_device,
+            )
+        else:
+            self.norm_added_q = None
+            self.norm_added_k = None
+
+        # Compute config
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+        self.core_grid = mesh_device.compute_with_storage_grid_size()
+
+    def __call__(self, x, seq_len, added_input=None, added_seq_len=None):
+        """
+        Forward pass.
+        Args:
+            x: [1, B, seq_len, dim] - main input
+            seq_len: sequence length for main input
+            added_input: [1, B, added_seq_len, added_proj_dim] - optional added context
+            added_seq_len: sequence length for added input
+        Returns:
+            [1, B, seq_len, dim] or tuple if added_input provided
+        """
+        B = x.shape[1]
+
+        # Main attention projections
+        q = self.to_q(x)  # [1, B, seq_len, dim]
+        k = self.to_k(x)
+        v = self.to_v(x)
+
+        # Reshape to [B, seq_len, num_heads, head_dim] BEFORE applying RMSNorm
+        q = ttnn.reshape(q, (B, seq_len, self.num_heads, self.head_dim))
+        k = ttnn.reshape(k, (B, seq_len, self.num_heads, self.head_dim))
+        v = ttnn.reshape(v, (B, seq_len, self.num_heads, self.head_dim))
+
+        # Apply RMSNorm to Q and K AFTER reshaping (now head_dim=64 matches norm)
+        if self.norm_q is not None:
+            q = self.norm_q(q)
+            k = self.norm_k(k)
+
+        # Transpose to [B, num_heads, seq_len, head_dim]
+        q = ttnn.permute(q, (0, 2, 1, 3))
+        k = ttnn.permute(k, (0, 2, 1, 3))
+        v = ttnn.permute(v, (0, 2, 1, 3))
+
+        # SDPA program config
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=self.core_grid,
+            q_chunk_size=64,
+            k_chunk_size=64,
+        )
+
+        # Handle added context if provided - SD3 uses JOINT attention (concatenate, attend, split)
+        if added_input is not None:
+            added_B = added_input.shape[1]
+
+            # Added attention projections
+            added_q = self.add_q_proj(added_input)
+            added_k = self.add_k_proj(added_input)
+            added_v = self.add_v_proj(added_input)
+
+            # Reshape added tensors to [B, added_seq_len, num_heads, head_dim] BEFORE applying RMSNorm
+            added_q = ttnn.reshape(added_q, (added_B, added_seq_len, self.num_heads, self.head_dim))
+            added_k = ttnn.reshape(added_k, (added_B, added_seq_len, self.num_heads, self.head_dim))
+            added_v = ttnn.reshape(added_v, (added_B, added_seq_len, self.num_heads, self.head_dim))
+
+            # Apply RMSNorm to added Q and K AFTER reshaping (now head_dim=64 matches norm)
+            if self.norm_added_q is not None:
+                added_q = self.norm_added_q(added_q)
+                added_k = self.norm_added_k(added_k)
+
+            # Transpose added tensors to [B, num_heads, added_seq_len, head_dim]
+            added_q = ttnn.permute(added_q, (0, 2, 1, 3))
+            added_k = ttnn.permute(added_k, (0, 2, 1, 3))
+            added_v = ttnn.permute(added_v, (0, 2, 1, 3))
+
+            # JOINT ATTENTION: Concatenate x and context along sequence dimension
+            # q: [B, num_heads, seq_len, head_dim], added_q: [B, num_heads, added_seq_len, head_dim]
+            # Result: [B, num_heads, seq_len + added_seq_len, head_dim]
+            q_full = ttnn.concat([q, added_q], dim=2)
+            k_full = ttnn.concat([k, added_k], dim=2)
+            v_full = ttnn.concat([v, added_v], dim=2)
+
+            # Run unified self-attention on concatenated sequence
+            attn_out_full = ttnn.transformer.scaled_dot_product_attention(
+                q_full,
+                k_full,
+                v_full,
+                is_causal=False,
+                scale=self.scale,
+                program_config=program_config,
+                compute_kernel_config=self.compute_kernel_config,
+            )
+            # Output shape: [B, num_heads, seq_len + added_seq_len, head_dim]
+
+            # Split output back into x and context parts
+            # attn_out: [B, num_heads, seq_len, head_dim]
+            # added_attn_out: [B, num_heads, added_seq_len, head_dim]
+            attn_out = attn_out_full[:, :, :seq_len, :]
+            added_attn_out = attn_out_full[:, :, seq_len:, :]
+
+            # Transpose back: [B, num_heads, seq_len, head_dim] -> [B, seq_len, num_heads, head_dim]
+            attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))
+            added_attn_out = ttnn.permute(added_attn_out, (0, 2, 1, 3))
+
+            # Reshape to [1, B, seq_len, inner_dim]
+            attn_out = ttnn.reshape(attn_out, (1, B, seq_len, self.inner_dim))
+            added_attn_out = ttnn.reshape(added_attn_out, (1, added_B, added_seq_len, self.inner_dim))
+
+            # Output projections
+            if not self.pre_only:
+                attn_out = self.to_out(attn_out)
+                if self.dropout_prob > 0.0:
+                    attn_out = ttnn.experimental.dropout(
+                        attn_out, probability=self.dropout_prob, scale=1.0 / (1.0 - self.dropout_prob)
+                    )
+
+            # Project added attention output back to added dimension (skip for final block)
+            if not self.context_pre_only:
+                added_attn_out = self.to_add_out(added_attn_out)
+
+            return attn_out, added_attn_out
+
+        # No added input - just self-attention on x
+        attn_out = ttnn.transformer.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=False,
+            scale=self.scale,
+            program_config=program_config,
+            compute_kernel_config=self.compute_kernel_config,
+        )
+
+        # Transpose back: [B, num_heads, seq_len, head_dim] -> [B, seq_len, num_heads, head_dim]
+        attn_out = ttnn.permute(attn_out, (0, 2, 1, 3))
+
+        # Reshape to [1, B, seq_len, inner_dim]
+        attn_out = ttnn.reshape(attn_out, (1, B, seq_len, self.inner_dim))
+
+        # Output projection
+        if not self.pre_only:
+            attn_out = self.to_out(attn_out)
+            if self.dropout_prob > 0.0:
+                attn_out = ttnn.experimental.dropout(
+                    attn_out, probability=self.dropout_prob, scale=1.0 / (1.0 - self.dropout_prob)
+                )
+
+        return attn_out
+
+    def load_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        # Load main attention weights
+        self.to_q.load_torch_state_dict(substate(state_dict, "to_q"))
+        self.to_k.load_torch_state_dict(substate(state_dict, "to_k"))
+        self.to_v.load_torch_state_dict(substate(state_dict, "to_v"))
+
+        # Load added context weights (only if present - attn2 doesn't have these)
+        add_q_state = substate(state_dict, "add_q_proj")
+        if add_q_state:
+            self.add_q_proj.load_torch_state_dict(add_q_state)
+            self.add_k_proj.load_torch_state_dict(substate(state_dict, "add_k_proj"))
+            self.add_v_proj.load_torch_state_dict(substate(state_dict, "add_v_proj"))
+            # to_add_out only exists in early/middle blocks, not final block
+            if not self.context_pre_only:
+                to_add_out_state = substate(state_dict, "to_add_out")
+                if to_add_out_state:
+                    self.to_add_out.load_torch_state_dict(to_add_out_state)
+
+        # Load output projection weights
+        if not self.pre_only:
+            self.to_out.load_torch_state_dict(substate(state_dict, "to_out.0"))
+
+        # Load normalization weights
+        if self.norm_q is not None:
+            self.norm_q.load_torch_state_dict(substate(state_dict, "norm_q"))
+            self.norm_k.load_torch_state_dict(substate(state_dict, "norm_k"))
+            # Only load added norm weights if present (attn2 doesn't have these)
+            norm_added_q_state = substate(state_dict, "norm_added_q")
+            if norm_added_q_state:
+                self.norm_added_q.load_torch_state_dict(norm_added_q_state)
+                self.norm_added_k.load_torch_state_dict(substate(state_dict, "norm_added_k"))

--- a/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
@@ -13,20 +13,6 @@ class AdaLayerNormZero(Module):
     """
     AdaLayerNormZero with 6x scaling for SD3.5 Medium.
 
-    Diffusers implementation:
-    ```python
-    class AdaLayerNormZero(nn.Module):
-        def __init__(self, embedding_dim, num_embeddings=None, norm_type="layer_norm", bias=True):
-            self.silu = nn.SiLU()
-            self.linear = nn.Linear(embedding_dim, 6 * embedding_dim, bias=bias)
-            self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
-
-        def forward(self, x, emb=None):
-            emb = self.linear(self.silu(emb))  # Note: SiLU BEFORE linear!
-            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = emb.chunk(6, dim=1)
-            x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
-            return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
-    ```
     """
 
     def __init__(
@@ -92,8 +78,7 @@ class AdaLayerNormContinuous(Module):
     """
     AdaLayerNormContinuous with 2x scaling for SD3.5 Medium block 23.
 
-    Diffusers implementation applies shift and scale directly:
-    x = self.norm(x) * (1 + scale) + shift
+    Diffusers implementation applies shift and scale directly
     """
 
     def __init__(
@@ -162,20 +147,6 @@ class SD35AdaLayerNormZeroX(Module):
     This is used for hidden_states (x) in early blocks.
     Outputs 9 modulation params: 3 for attn, 3 for mlp, 3 for attn2.
 
-    Diffusers implementation:
-    ```python
-    class SD35AdaLayerNormZeroX(nn.Module):
-        def __init__(self, embedding_dim, norm_type="layer_norm", bias=True):
-            self.silu = nn.SiLU()
-            self.linear = nn.Linear(embedding_dim, 9 * embedding_dim, bias=bias)
-            self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
-
-        def forward(self, x, emb):
-            emb = self.linear(self.silu(emb))  # SiLU BEFORE linear!
-            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp, shift_msa2, scale_msa2, gate_msa2 = emb.chunk(9, dim=1)
-            x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
-            return x, gate_msa, shift_mlp, scale_mlp, gate_mlp, shift_msa2, scale_msa2, gate_msa2
-    ```
     """
 
     def __init__(
@@ -387,7 +358,6 @@ class JointTransformerBlockEarly(Module):
         """Load weights from PyTorch state dict."""
         self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
         self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
-        # norm2 and norm2_context have norm_elementwise_affine=False, no weights to load
         self.attn.load_state_dict(substate(state_dict, "attn"))
         self.attn2.load_state_dict(substate(state_dict, "attn2"))
         self.ff.load_torch_state_dict(substate(state_dict, "ff"))
@@ -476,8 +446,6 @@ class JointTransformerBlockMiddle(Module):
         # Apply gate and residual for joint attention
         x = x + x_gate_msa * attn_out
         context = context + c_gate_msa * context_attn_out
-
-        # NOTE: Middle blocks do NOT use attn2 - only early blocks (0-12) use it
 
         # Feed forward
         x_norm_ff = self.norm2(x)
@@ -602,5 +570,4 @@ class JointTransformerBlockFinal(Module):
         self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
         self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
         self.attn.load_state_dict(substate(state_dict, "attn"))
-        # NOTE: Final block does NOT have attn2
         self.ff.load_torch_state_dict(substate(state_dict, "ff"))

--- a/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
@@ -57,7 +57,7 @@ class AdaLayerNormZero(Module):
         """
         Args:
             x: Input tensor [1, B, seq_len, hidden_size]
-            c: Conditioning tensor [1, B, hidden_size] (temb after passing through time embedding)
+            c: Conditioning tensor [1, B, hidden_size] or [1, 1, B, hidden_size] when guidance_cond=2
         Returns:
             normalized_x: Normalized input [1, B, seq_len, hidden_size]
             scale: Modulation params [1, B, 6, hidden_size]
@@ -69,8 +69,17 @@ class AdaLayerNormZero(Module):
         c_silu = ttnn.silu(c)
         c_processed = self.linear(c_silu)
 
+        # Handle different input shapes: [1, B, hidden_size] or [1, 1, B, hidden_size] (guidance_cond=2)
+        # Get batch dimension from the appropriate axis
+        if len(c_processed.shape) == 4:
+            # Shape is [1, 1, B, conditioning_size] - use shape[2] for batch
+            batch_dim = c_processed.shape[2]
+        else:
+            # Shape is [1, B, conditioning_size] - use shape[1] for batch
+            batch_dim = c_processed.shape[1]
+
         # Reshape to [1, B, 6, hidden_size]
-        scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 6, self.hidden_size))
+        scale = ttnn.reshape(c_processed, (1, batch_dim, 6, self.hidden_size))
 
         return normalized_x, scale
 
@@ -115,7 +124,7 @@ class AdaLayerNormContinuous(Module):
         """
         Args:
             x: Input tensor [1, B, seq_len, hidden_size]
-            c: Conditioning tensor [1, B, hidden_size]
+            c: Conditioning tensor [1, B, hidden_size] or [1, 1, B, hidden_size] when guidance_cond=2
         Returns:
             normalized_x: Normalized input
             scale: Modulation params [1, B, 2, hidden_size] (shift, scale)
@@ -127,8 +136,17 @@ class AdaLayerNormContinuous(Module):
         c_silu = ttnn.silu(c)
         c_processed = self.linear(c_silu)
 
+        # Handle different input shapes: [1, B, hidden_size] or [1, 1, B, hidden_size] (guidance_cond=2)
+        # Get batch dimension from the appropriate axis
+        if len(c_processed.shape) == 4:
+            # Shape is [1, 1, B, conditioning_size] - use shape[2] for batch
+            batch_dim = c_processed.shape[2]
+        else:
+            # Shape is [1, B, conditioning_size] - use shape[1] for batch
+            batch_dim = c_processed.shape[1]
+
         # Reshape
-        scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 2, self.hidden_size))
+        scale = ttnn.reshape(c_processed, (1, batch_dim, 2, self.hidden_size))
 
         return normalized_x, scale
 
@@ -188,7 +206,7 @@ class SD35AdaLayerNormZeroX(Module):
         """
         Args:
             x: Input tensor [1, B, seq_len, hidden_size]
-            c: Conditioning tensor [1, B, hidden_size]
+            c: Conditioning tensor [1, B, hidden_size] or [1, 1, B, hidden_size] when guidance_cond=2
         Returns:
             normalized_x: Normalized input [1, B, seq_len, hidden_size]
             scale: Modulation params [1, B, 9, hidden_size]
@@ -201,8 +219,17 @@ class SD35AdaLayerNormZeroX(Module):
         c_silu = ttnn.silu(c)
         c_processed = self.linear(c_silu)
 
-        # Reshape
-        scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 9, self.hidden_size))
+        # Handle different input shapes: [1, B, hidden_size] or [1, 1, B, hidden_size] (guidance_cond=2)
+        # Get batch dimension from the appropriate axis
+        if len(c_processed.shape) == 4:
+            # Shape is [1, 1, B, conditioning_size] - use shape[2] for batch
+            batch_dim = c_processed.shape[2]
+        else:
+            # Shape is [1, B, conditioning_size] - use shape[1] for batch
+            batch_dim = c_processed.shape[1]
+
+        # Reshape: conditioning_size = 9 * hidden_size
+        scale = ttnn.reshape(c_processed, (1, batch_dim, 9, self.hidden_size))
 
         return normalized_x, scale
 

--- a/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
@@ -1,0 +1,590 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.tt_dit.layers.module import Module
+from models.experimental.tt_dit.layers.linear import Linear
+from models.experimental.tt_dit.layers.normalization import LayerNorm
+from models.experimental.tt_dit.models.transformers.sd35_med.attention_sd35_medium import SD35MediumSelfAttention
+from models.experimental.tt_dit.utils.substate import substate
+
+# =============================================================================
+# Inlined AdaLayerNorm Implementations
+# =============================================================================
+
+
+class AdaLayerNormZero(Module):
+    """
+    AdaLayerNormZero with 6x scaling for SD3.5 Medium.
+
+    Diffusers implementation:
+    ```python
+    class AdaLayerNormZero(nn.Module):
+        def __init__(self, embedding_dim, num_embeddings=None, norm_type="layer_norm", bias=True):
+            self.silu = nn.SiLU()
+            self.linear = nn.Linear(embedding_dim, 6 * embedding_dim, bias=bias)
+            self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
+
+        def forward(self, x, emb=None):
+            emb = self.linear(self.silu(emb))  # Note: SiLU BEFORE linear!
+            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = emb.chunk(6, dim=1)
+            x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+            return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+    ```
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        conditioning_size: int,
+        bias: bool = True,
+        mesh_device=None,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.conditioning_size = conditioning_size
+        self.mesh_device = mesh_device
+
+        # Linear layer to process conditioning (hidden_size -> 6*hidden_size)
+        self.linear = Linear(hidden_size, conditioning_size, bias=bias, mesh_device=mesh_device)
+
+        # Layer norm (no learnable params)
+        self.norm = LayerNorm(
+            hidden_size,
+            norm_eps=eps,
+            norm_elementwise_affine=False,
+            mesh_device=mesh_device,
+        )
+
+    def forward(self, x, c):
+        """
+        Args:
+            x: Input tensor [1, B, seq_len, hidden_size]
+            c: Conditioning tensor [1, B, hidden_size] (temb after passing through time embedding)
+        Returns:
+            normalized_x: Normalized input [1, B, seq_len, hidden_size]
+            scale: Modulation params [1, B, 6, hidden_size]
+        """
+        # Apply layer norm to input
+        normalized_x = self.norm(x)
+
+        # Process conditioning: SiLU FIRST, then linear (matching Diffusers)
+        c_silu = ttnn.silu(c)
+        c_processed = self.linear(c_silu)
+
+        # Reshape to [1, B, 6, hidden_size]
+        scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 6, self.hidden_size))
+
+        return normalized_x, scale
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.linear.load_torch_state_dict(substate(state_dict, "linear"))
+
+
+class AdaLayerNormContinuous(Module):
+    """
+    AdaLayerNormContinuous with 2x scaling for SD3.5 Medium block 23.
+
+    Diffusers implementation applies shift and scale directly:
+    x = self.norm(x) * (1 + scale) + shift
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        conditioning_size: int,
+        bias: bool = True,
+        mesh_device=None,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.conditioning_size = conditioning_size
+        self.mesh_device = mesh_device
+
+        # Linear layer to process conditioning
+        self.linear = Linear(hidden_size, conditioning_size, bias=bias, mesh_device=mesh_device)
+
+        # Layer norm
+        self.norm = LayerNorm(
+            hidden_size,
+            norm_eps=eps,
+            norm_elementwise_affine=False,
+            mesh_device=mesh_device,
+        )
+
+    def forward(self, x, c):
+        """
+        Args:
+            x: Input tensor [1, B, seq_len, hidden_size]
+            c: Conditioning tensor [1, B, hidden_size]
+        Returns:
+            normalized_x: Normalized input
+            scale: Modulation params [1, B, 2, hidden_size] (shift, scale)
+        """
+        # Apply layer norm
+        normalized_x = self.norm(x)
+
+        # Process conditioning: SiLU FIRST, then linear
+        c_silu = ttnn.silu(c)
+        c_processed = self.linear(c_silu)
+
+        # Reshape to [1, B, 2, hidden_size]
+        scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 2, self.hidden_size))
+
+        return normalized_x, scale
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.linear.load_torch_state_dict(substate(state_dict, "linear"))
+
+
+class SD35AdaLayerNormZeroX(Module):
+    """
+    SD35AdaLayerNormZeroX with 9x scaling for SD3.5 Medium blocks 0-12.
+
+    This is used for hidden_states (x) in early blocks.
+    Outputs 9 modulation params: 3 for attn, 3 for mlp, 3 for attn2.
+
+    Diffusers implementation:
+    ```python
+    class SD35AdaLayerNormZeroX(nn.Module):
+        def __init__(self, embedding_dim, norm_type="layer_norm", bias=True):
+            self.silu = nn.SiLU()
+            self.linear = nn.Linear(embedding_dim, 9 * embedding_dim, bias=bias)
+            self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
+
+        def forward(self, x, emb):
+            emb = self.linear(self.silu(emb))  # SiLU BEFORE linear!
+            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp, shift_msa2, scale_msa2, gate_msa2 = emb.chunk(9, dim=1)
+            x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+            return x, gate_msa, shift_mlp, scale_mlp, gate_mlp, shift_msa2, scale_msa2, gate_msa2
+    ```
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        conditioning_size: int,
+        bias: bool = True,
+        mesh_device=None,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.conditioning_size = conditioning_size
+        self.mesh_device = mesh_device
+
+        # Linear layer to process conditioning (hidden_size -> 9*hidden_size)
+        self.linear = Linear(hidden_size, conditioning_size, bias=bias, mesh_device=mesh_device)
+
+        # Layer norm (no learnable params)
+        self.norm = LayerNorm(
+            hidden_size,
+            norm_eps=eps,
+            norm_elementwise_affine=False,
+            mesh_device=mesh_device,
+        )
+
+    def forward(self, x, c):
+        """
+        Args:
+            x: Input tensor [1, B, seq_len, hidden_size]
+            c: Conditioning tensor [1, B, hidden_size]
+        Returns:
+            normalized_x: Normalized input [1, B, seq_len, hidden_size]
+            scale: Modulation params [1, B, 9, hidden_size]
+            Order: shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp, shift_msa2, scale_msa2, gate_msa2
+        """
+        # Apply layer norm to input
+        normalized_x = self.norm(x)
+
+        # Process conditioning: SiLU FIRST, then linear (matching Diffusers!)
+        c_silu = ttnn.silu(c)
+        c_processed = self.linear(c_silu)
+
+        # Reshape to [1, B, 9, hidden_size]
+        scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 9, self.hidden_size))
+
+        return normalized_x, scale
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.linear.load_torch_state_dict(substate(state_dict, "linear"))
+
+
+# =============================================================================
+# Joint Transformer Block Implementations
+# =============================================================================
+
+
+class FeedForward(Module):
+    """FeedForward network with GELU activation."""
+
+    def __init__(self, dim, hidden_dim, mesh_device=None):
+        super().__init__()
+        self.mesh_device = mesh_device
+
+        # Linear layers
+        self.net = [
+            Linear(dim, hidden_dim, bias=True, mesh_device=mesh_device),
+            None,  # Dropout placeholder
+            Linear(hidden_dim, dim, bias=True, mesh_device=mesh_device),
+        ]
+
+    def forward(self, x):
+        # First linear with GELU
+        x = self.net[0](x)
+        x = ttnn.gelu(x)
+
+        # Second linear
+        x = self.net[2](x)
+        return x
+
+    def load_torch_state_dict(self, state_dict):
+        self.net[0].load_torch_state_dict(substate(state_dict, "net.0.proj"))
+        self.net[2].load_torch_state_dict(substate(state_dict, "net.2"))
+
+
+class JointTransformerBlockEarly(Module):
+    """JointTransformerBlock for blocks 0-12 (SD35AdaLayerNormZeroX + AdaLayerNormZero)"""
+
+    def __init__(self, dim: int = 1536, num_heads: int = 24, mesh_device=None, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.mesh_device = mesh_device
+
+        # Blocks 0-12: SD35AdaLayerNormZeroX + AdaLayerNormZero
+        self.norm1 = SD35AdaLayerNormZeroX(
+            hidden_size=dim, conditioning_size=13824, bias=True, mesh_device=mesh_device, eps=eps  # 9x scaling
+        )
+        self.norm1_context = AdaLayerNormZero(
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+        )
+
+        # Attention layers
+        self.attn = SD35MediumSelfAttention(
+            dim=dim,
+            num_heads=num_heads,
+            qkv_bias=True,
+            pre_only=False,
+            qk_norm="rms",
+            eps=eps,
+            mesh_device=mesh_device,
+            added_proj_dim=dim,
+        )
+
+        self.attn2 = SD35MediumSelfAttention(
+            dim=dim,
+            num_heads=num_heads,
+            qkv_bias=True,
+            pre_only=False,
+            qk_norm="rms",
+            eps=eps,
+            mesh_device=mesh_device,
+            added_proj_dim=None,
+        )
+
+        # Post-attention normalization
+        self.norm2 = LayerNorm(dim, norm_eps=eps, norm_elementwise_affine=False, mesh_device=mesh_device)
+        self.norm2_context = LayerNorm(dim, norm_eps=eps, norm_elementwise_affine=False, mesh_device=mesh_device)
+
+        # Feed forward networks
+        self.ff = FeedForward(dim=dim, hidden_dim=6144, mesh_device=mesh_device)
+        self.ff_context = FeedForward(dim=dim, hidden_dim=6144, mesh_device=mesh_device)
+
+    def forward(self, x, context, conditioning, seq_len, context_seq_len):
+        """Forward pass for early blocks (0-12)
+
+        SD35AdaLayerNormZeroX outputs 9 modulation params:
+        - 0-2: shift_msa, scale_msa, gate_msa (for joint attn)
+        - 3-5: shift_mlp, scale_mlp, gate_mlp (for feedforward)
+        - 6-8: shift_msa2, scale_msa2, gate_msa2 (for self-attn2)
+
+        AdaLayerNormZero outputs 6 modulation params:
+        - 0-2: shift_msa, scale_msa, gate_msa (for joint attn)
+        - 3-5: shift_mlp, scale_mlp, gate_mlp (for feedforward)
+        """
+        # First normalization with conditioning
+        x_norm, x_scale = self.norm1(x, conditioning)
+        context_norm, context_scale = self.norm1_context(context, conditioning)
+
+        # Extract x modulation params (9 total for SD35AdaLayerNormZeroX)
+        x_shift_msa = x_scale[:, :, 0:1, :]
+        x_scale_msa = x_scale[:, :, 1:2, :]
+        x_gate_msa = x_scale[:, :, 2:3, :]
+        x_shift_mlp = x_scale[:, :, 3:4, :]
+        x_scale_mlp = x_scale[:, :, 4:5, :]
+        x_gate_mlp = x_scale[:, :, 5:6, :]
+        x_shift_msa2 = x_scale[:, :, 6:7, :]
+        x_scale_msa2 = x_scale[:, :, 7:8, :]
+        x_gate_msa2 = x_scale[:, :, 8:9, :]
+
+        # Extract context modulation params (6 total for AdaLayerNormZero)
+        c_shift_msa = context_scale[:, :, 0:1, :]
+        c_scale_msa = context_scale[:, :, 1:2, :]
+        c_gate_msa = context_scale[:, :, 2:3, :]
+        c_shift_mlp = context_scale[:, :, 3:4, :]
+        c_scale_mlp = context_scale[:, :, 4:5, :]
+        c_gate_mlp = context_scale[:, :, 5:6, :]
+
+        # Apply modulation for joint attention
+        x_modulated = x_norm * (1 + x_scale_msa) + x_shift_msa
+        context_modulated = context_norm * (1 + c_scale_msa) + c_shift_msa
+
+        # Joint attention (attn) - x and context attend together
+        attn_out, context_attn_out = self.attn(
+            x_modulated, seq_len, added_input=context_modulated, added_seq_len=context_seq_len
+        )
+
+        # Apply gate and residual for joint attention (NO silu on gate!)
+        x = x + x_gate_msa * attn_out
+        context = context + c_gate_msa * context_attn_out
+
+        # Second attention (attn2) - self-attention on x only
+        x_norm2 = self.norm2(x)
+        x_modulated2 = x_norm2 * (1 + x_scale_msa2) + x_shift_msa2
+        attn2_out = self.attn2(x_modulated2, seq_len)
+        x = x + x_gate_msa2 * attn2_out
+
+        # Feed forward
+        x_norm_ff = self.norm2(x)
+        context_norm_ff = self.norm2_context(context)
+
+        x_modulated_ff = x_norm_ff * (1 + x_scale_mlp) + x_shift_mlp
+        context_modulated_ff = context_norm_ff * (1 + c_scale_mlp) + c_shift_mlp
+
+        ff_out = self.ff(x_modulated_ff)
+        context_ff_out = self.ff_context(context_modulated_ff)
+
+        x = x + x_gate_mlp * ff_out
+        context = context + c_gate_mlp * context_ff_out
+
+        return x, context
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
+        self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
+        # norm2 and norm2_context have norm_elementwise_affine=False, no weights to load
+        self.attn.load_state_dict(substate(state_dict, "attn"))
+        self.attn2.load_state_dict(substate(state_dict, "attn2"))
+        self.ff.load_torch_state_dict(substate(state_dict, "ff"))
+        self.ff_context.load_torch_state_dict(substate(state_dict, "ff_context"))
+
+
+class JointTransformerBlockMiddle(Module):
+    """JointTransformerBlock for blocks 13-22 (AdaLayerNormZero + AdaLayerNormZero)
+
+    Middle blocks do NOT have attn2 - only joint attention (attn).
+    """
+
+    def __init__(self, dim: int = 1536, num_heads: int = 24, mesh_device=None, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.mesh_device = mesh_device
+
+        # Blocks 13-22: AdaLayerNormZero + AdaLayerNormZero
+        self.norm1 = AdaLayerNormZero(
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+        )
+        self.norm1_context = AdaLayerNormZero(
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+        )
+
+        # Only joint attention (no attn2 in middle blocks!)
+        self.attn = SD35MediumSelfAttention(
+            dim=dim,
+            num_heads=num_heads,
+            qkv_bias=True,
+            pre_only=False,
+            qk_norm="rms",
+            eps=eps,
+            mesh_device=mesh_device,
+            added_proj_dim=dim,
+        )
+
+        # Post-attention normalization
+        self.norm2 = LayerNorm(dim, norm_eps=eps, norm_elementwise_affine=False, mesh_device=mesh_device)
+        self.norm2_context = LayerNorm(dim, norm_eps=eps, norm_elementwise_affine=False, mesh_device=mesh_device)
+
+        # Feed forward networks
+        self.ff = FeedForward(dim=dim, hidden_dim=6144, mesh_device=mesh_device)
+        self.ff_context = FeedForward(dim=dim, hidden_dim=6144, mesh_device=mesh_device)
+
+    def forward(self, x, context, conditioning, seq_len, context_seq_len):
+        """Forward pass for middle blocks (13-22)
+
+        Middle blocks use AdaLayerNormZero (6 params) for both x and context.
+        Unlike early blocks, middle blocks do NOT use attn2 in forward pass.
+
+        AdaLayerNormZero outputs 6 modulation params:
+        - 0-2: shift_msa, scale_msa, gate_msa (for joint attn)
+        - 3-5: shift_mlp, scale_mlp, gate_mlp (for feedforward)
+        """
+        # First normalization with conditioning
+        x_norm, x_scale = self.norm1(x, conditioning)
+        context_norm, context_scale = self.norm1_context(context, conditioning)
+
+        # Extract x modulation params (6 total for AdaLayerNormZero)
+        x_shift_msa = x_scale[:, :, 0:1, :]
+        x_scale_msa = x_scale[:, :, 1:2, :]
+        x_gate_msa = x_scale[:, :, 2:3, :]
+        x_shift_mlp = x_scale[:, :, 3:4, :]
+        x_scale_mlp = x_scale[:, :, 4:5, :]
+        x_gate_mlp = x_scale[:, :, 5:6, :]
+
+        # Extract context modulation params (6 total for AdaLayerNormZero)
+        c_shift_msa = context_scale[:, :, 0:1, :]
+        c_scale_msa = context_scale[:, :, 1:2, :]
+        c_gate_msa = context_scale[:, :, 2:3, :]
+        c_shift_mlp = context_scale[:, :, 3:4, :]
+        c_scale_mlp = context_scale[:, :, 4:5, :]
+        c_gate_mlp = context_scale[:, :, 5:6, :]
+
+        # Apply modulation for joint attention
+        x_modulated = x_norm * (1 + x_scale_msa) + x_shift_msa
+        context_modulated = context_norm * (1 + c_scale_msa) + c_shift_msa
+
+        # Joint attention (attn) - x and context attend together
+        attn_out, context_attn_out = self.attn(
+            x_modulated, seq_len, added_input=context_modulated, added_seq_len=context_seq_len
+        )
+
+        # Apply gate and residual for joint attention (NO silu on gate!)
+        x = x + x_gate_msa * attn_out
+        context = context + c_gate_msa * context_attn_out
+
+        # NOTE: Middle blocks do NOT use attn2 - only early blocks (0-12) use it
+
+        # Feed forward
+        x_norm_ff = self.norm2(x)
+        context_norm_ff = self.norm2_context(context)
+
+        x_modulated_ff = x_norm_ff * (1 + x_scale_mlp) + x_shift_mlp
+        context_modulated_ff = context_norm_ff * (1 + c_scale_mlp) + c_shift_mlp
+
+        ff_out = self.ff(x_modulated_ff)
+        context_ff_out = self.ff_context(context_modulated_ff)
+
+        x = x + x_gate_mlp * ff_out
+        context = context + c_gate_mlp * context_ff_out
+
+        return x, context
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
+        self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
+        # norm2 and norm2_context have norm_elementwise_affine=False, no weights to load
+        self.attn.load_state_dict(substate(state_dict, "attn"))
+        # NOTE: Middle blocks do NOT have attn2
+        self.ff.load_torch_state_dict(substate(state_dict, "ff"))
+        self.ff_context.load_torch_state_dict(substate(state_dict, "ff_context"))
+
+
+class JointTransformerBlockFinal(Module):
+    """JointTransformerBlock for block 23 (AdaLayerNormZero + AdaLayerNormContinuous)
+
+    Final block differences:
+    - NO attn2
+    - NO to_add_out in attention (context doesn't get output projection)
+    - NO norm2_context or ff_context (only processes x after attention)
+    - AdaLayerNormContinuous for context outputs only 2 params (shift, scale) - no gate
+    """
+
+    def __init__(self, dim: int = 1536, num_heads: int = 24, mesh_device=None, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.mesh_device = mesh_device
+
+        # Block 23: AdaLayerNormZero + AdaLayerNormContinuous
+        self.norm1 = AdaLayerNormZero(
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+        )
+        self.norm1_context = AdaLayerNormContinuous(
+            hidden_size=dim, conditioning_size=3072, bias=True, mesh_device=mesh_device, eps=eps  # 2x scaling
+        )
+
+        # Only joint attention (no attn2, no to_add_out for context)
+        self.attn = SD35MediumSelfAttention(
+            dim=dim,
+            num_heads=num_heads,
+            qkv_bias=True,
+            pre_only=False,
+            qk_norm="rms",
+            eps=eps,
+            mesh_device=mesh_device,
+            added_proj_dim=dim,
+            context_pre_only=True,  # Final block: no to_add_out for context
+        )
+
+        # Post-attention normalization (only for x)
+        self.norm2 = LayerNorm(dim, norm_eps=eps, norm_elementwise_affine=False, mesh_device=mesh_device)
+
+        # Feed forward network (only for x, no ff_context)
+        self.ff = FeedForward(dim=dim, hidden_dim=6144, mesh_device=mesh_device)
+
+    def forward(self, x, context, conditioning, seq_len, context_seq_len):
+        """Forward pass for final block (23)
+
+        AdaLayerNormZero outputs 6 modulation params for x:
+        - 0-2: shift_msa, scale_msa, gate_msa (for joint attn)
+        - 3-5: shift_mlp, scale_mlp, gate_mlp (for feedforward)
+
+        AdaLayerNormContinuous outputs 2 modulation params for context:
+        - 0: shift (for joint attn)
+        - 1: scale (for joint attn)
+        - NO gate for context!
+        """
+        # First normalization with conditioning
+        x_norm, x_scale = self.norm1(x, conditioning)
+        context_norm, context_scale = self.norm1_context(context, conditioning)
+
+        # Extract x modulation params (6 total for AdaLayerNormZero)
+        x_shift_msa = x_scale[:, :, 0:1, :]
+        x_scale_msa = x_scale[:, :, 1:2, :]
+        x_gate_msa = x_scale[:, :, 2:3, :]
+        x_shift_mlp = x_scale[:, :, 3:4, :]
+        x_scale_mlp = x_scale[:, :, 4:5, :]
+        x_gate_mlp = x_scale[:, :, 5:6, :]
+
+        # Extract context modulation params (2 total for AdaLayerNormContinuous)
+        c_shift = context_scale[:, :, 0:1, :]
+        c_scale = context_scale[:, :, 1:2, :]
+
+        # Apply modulation for joint attention
+        x_modulated = x_norm * (1 + x_scale_msa) + x_shift_msa
+        context_modulated = context_norm * (1 + c_scale) + c_shift
+
+        # Joint attention - note: final block doesn't have to_add_out for context
+        attn_out, context_attn_out = self.attn(
+            x_modulated, seq_len, added_input=context_modulated, added_seq_len=context_seq_len
+        )
+
+        # Apply gate and residual for x (context has no gate in final block)
+        x = x + x_gate_msa * attn_out
+        # Context: just residual, no gate (AdaLayerNormContinuous has no gate)
+        context = context + context_attn_out
+
+        # Feed forward (only for x)
+        x_norm_ff = self.norm2(x)
+        x_modulated_ff = x_norm_ff * (1 + x_scale_mlp) + x_shift_mlp
+        ff_out = self.ff(x_modulated_ff)
+        x = x + x_gate_mlp * ff_out
+
+        return x, context
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
+        self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
+        # norm2 has norm_elementwise_affine=False, no weights to load
+        self.attn.load_state_dict(substate(state_dict, "attn"))
+        # NOTE: Final block does NOT have attn2
+        self.ff.load_torch_state_dict(substate(state_dict, "ff"))

--- a/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
@@ -7,10 +7,6 @@ from models.experimental.tt_dit.layers.linear import Linear
 from models.experimental.tt_dit.layers.normalization import LayerNorm
 from models.experimental.tt_dit.models.transformers.sd35_med.attention_sd35_medium import SD35MediumSelfAttention
 from models.experimental.tt_dit.utils.substate import substate
-
-# =============================================================================
-# Inlined AdaLayerNorm Implementations
-# =============================================================================
 
 
 class AdaLayerNormZero(Module):
@@ -46,10 +42,10 @@ class AdaLayerNormZero(Module):
         self.conditioning_size = conditioning_size
         self.mesh_device = mesh_device
 
-        # Linear layer to process conditioning (hidden_size -> 6*hidden_size)
+        # Linear layer to process conditioning
         self.linear = Linear(hidden_size, conditioning_size, bias=bias, mesh_device=mesh_device)
 
-        # Layer norm (no learnable params)
+        # Layer norm
         self.norm = LayerNorm(
             hidden_size,
             norm_eps=eps,
@@ -69,7 +65,7 @@ class AdaLayerNormZero(Module):
         # Apply layer norm to input
         normalized_x = self.norm(x)
 
-        # Process conditioning: SiLU FIRST, then linear (matching Diffusers)
+        # Process conditioning: SiLU FIRST, then linear
         c_silu = ttnn.silu(c)
         c_processed = self.linear(c_silu)
 
@@ -131,7 +127,7 @@ class AdaLayerNormContinuous(Module):
         c_silu = ttnn.silu(c)
         c_processed = self.linear(c_silu)
 
-        # Reshape to [1, B, 2, hidden_size]
+        # Reshape
         scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 2, self.hidden_size))
 
         return normalized_x, scale
@@ -177,10 +173,10 @@ class SD35AdaLayerNormZeroX(Module):
         self.conditioning_size = conditioning_size
         self.mesh_device = mesh_device
 
-        # Linear layer to process conditioning (hidden_size -> 9*hidden_size)
+        # Linear layer to process conditioning
         self.linear = Linear(hidden_size, conditioning_size, bias=bias, mesh_device=mesh_device)
 
-        # Layer norm (no learnable params)
+        # Layer norm
         self.norm = LayerNorm(
             hidden_size,
             norm_eps=eps,
@@ -201,11 +197,11 @@ class SD35AdaLayerNormZeroX(Module):
         # Apply layer norm to input
         normalized_x = self.norm(x)
 
-        # Process conditioning: SiLU FIRST, then linear (matching Diffusers!)
+        # Process conditioning: SiLU FIRST, then linear
         c_silu = ttnn.silu(c)
         c_processed = self.linear(c_silu)
 
-        # Reshape to [1, B, 9, hidden_size]
+        # Reshape
         scale = ttnn.reshape(c_processed, (1, c_processed.shape[1], 9, self.hidden_size))
 
         return normalized_x, scale
@@ -213,11 +209,6 @@ class SD35AdaLayerNormZeroX(Module):
     def load_torch_state_dict(self, state_dict):
         """Load weights from PyTorch state dict."""
         self.linear.load_torch_state_dict(substate(state_dict, "linear"))
-
-
-# =============================================================================
-# Joint Transformer Block Implementations
-# =============================================================================
 
 
 class FeedForward(Module):
@@ -230,7 +221,7 @@ class FeedForward(Module):
         # Linear layers
         self.net = [
             Linear(dim, hidden_dim, bias=True, mesh_device=mesh_device),
-            None,  # Dropout placeholder
+            None,
             Linear(hidden_dim, dim, bias=True, mesh_device=mesh_device),
         ]
 
@@ -259,10 +250,10 @@ class JointTransformerBlockEarly(Module):
 
         # Blocks 0-12: SD35AdaLayerNormZeroX + AdaLayerNormZero
         self.norm1 = SD35AdaLayerNormZeroX(
-            hidden_size=dim, conditioning_size=13824, bias=True, mesh_device=mesh_device, eps=eps  # 9x scaling
+            hidden_size=dim, conditioning_size=13824, bias=True, mesh_device=mesh_device, eps=eps
         )
         self.norm1_context = AdaLayerNormZero(
-            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps
         )
 
         # Attention layers
@@ -312,7 +303,7 @@ class JointTransformerBlockEarly(Module):
         x_norm, x_scale = self.norm1(x, conditioning)
         context_norm, context_scale = self.norm1_context(context, conditioning)
 
-        # Extract x modulation params (9 total for SD35AdaLayerNormZeroX)
+        # Extract x modulation params
         x_shift_msa = x_scale[:, :, 0:1, :]
         x_scale_msa = x_scale[:, :, 1:2, :]
         x_gate_msa = x_scale[:, :, 2:3, :]
@@ -323,7 +314,7 @@ class JointTransformerBlockEarly(Module):
         x_scale_msa2 = x_scale[:, :, 7:8, :]
         x_gate_msa2 = x_scale[:, :, 8:9, :]
 
-        # Extract context modulation params (6 total for AdaLayerNormZero)
+        # Extract context modulation params
         c_shift_msa = context_scale[:, :, 0:1, :]
         c_scale_msa = context_scale[:, :, 1:2, :]
         c_gate_msa = context_scale[:, :, 2:3, :]
@@ -335,16 +326,16 @@ class JointTransformerBlockEarly(Module):
         x_modulated = x_norm * (1 + x_scale_msa) + x_shift_msa
         context_modulated = context_norm * (1 + c_scale_msa) + c_shift_msa
 
-        # Joint attention (attn) - x and context attend together
+        # Joint attention
         attn_out, context_attn_out = self.attn(
             x_modulated, seq_len, added_input=context_modulated, added_seq_len=context_seq_len
         )
 
-        # Apply gate and residual for joint attention (NO silu on gate!)
+        # Apply gate and residual for joint attention
         x = x + x_gate_msa * attn_out
         context = context + c_gate_msa * context_attn_out
 
-        # Second attention (attn2) - self-attention on x only
+        # Second attention
         x_norm2 = self.norm2(x)
         x_modulated2 = x_norm2 * (1 + x_scale_msa2) + x_shift_msa2
         attn2_out = self.attn2(x_modulated2, seq_len)
@@ -390,13 +381,13 @@ class JointTransformerBlockMiddle(Module):
 
         # Blocks 13-22: AdaLayerNormZero + AdaLayerNormZero
         self.norm1 = AdaLayerNormZero(
-            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps
         )
         self.norm1_context = AdaLayerNormZero(
-            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps
         )
 
-        # Only joint attention (no attn2 in middle blocks!)
+        # Only joint attention
         self.attn = SD35MediumSelfAttention(
             dim=dim,
             num_heads=num_heads,
@@ -430,7 +421,7 @@ class JointTransformerBlockMiddle(Module):
         x_norm, x_scale = self.norm1(x, conditioning)
         context_norm, context_scale = self.norm1_context(context, conditioning)
 
-        # Extract x modulation params (6 total for AdaLayerNormZero)
+        # Extract x modulation params
         x_shift_msa = x_scale[:, :, 0:1, :]
         x_scale_msa = x_scale[:, :, 1:2, :]
         x_gate_msa = x_scale[:, :, 2:3, :]
@@ -438,7 +429,7 @@ class JointTransformerBlockMiddle(Module):
         x_scale_mlp = x_scale[:, :, 4:5, :]
         x_gate_mlp = x_scale[:, :, 5:6, :]
 
-        # Extract context modulation params (6 total for AdaLayerNormZero)
+        # Extract context modulation params
         c_shift_msa = context_scale[:, :, 0:1, :]
         c_scale_msa = context_scale[:, :, 1:2, :]
         c_gate_msa = context_scale[:, :, 2:3, :]
@@ -450,12 +441,12 @@ class JointTransformerBlockMiddle(Module):
         x_modulated = x_norm * (1 + x_scale_msa) + x_shift_msa
         context_modulated = context_norm * (1 + c_scale_msa) + c_shift_msa
 
-        # Joint attention (attn) - x and context attend together
+        # Joint attention
         attn_out, context_attn_out = self.attn(
             x_modulated, seq_len, added_input=context_modulated, added_seq_len=context_seq_len
         )
 
-        # Apply gate and residual for joint attention (NO silu on gate!)
+        # Apply gate and residual for joint attention
         x = x + x_gate_msa * attn_out
         context = context + c_gate_msa * context_attn_out
 
@@ -480,7 +471,6 @@ class JointTransformerBlockMiddle(Module):
         """Load weights from PyTorch state dict."""
         self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
         self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
-        # norm2 and norm2_context have norm_elementwise_affine=False, no weights to load
         self.attn.load_state_dict(substate(state_dict, "attn"))
         # NOTE: Middle blocks do NOT have attn2
         self.ff.load_torch_state_dict(substate(state_dict, "ff"))
@@ -505,13 +495,13 @@ class JointTransformerBlockFinal(Module):
 
         # Block 23: AdaLayerNormZero + AdaLayerNormContinuous
         self.norm1 = AdaLayerNormZero(
-            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps  # 6x scaling
+            hidden_size=dim, conditioning_size=9216, bias=True, mesh_device=mesh_device, eps=eps
         )
         self.norm1_context = AdaLayerNormContinuous(
-            hidden_size=dim, conditioning_size=3072, bias=True, mesh_device=mesh_device, eps=eps  # 2x scaling
+            hidden_size=dim, conditioning_size=3072, bias=True, mesh_device=mesh_device, eps=eps
         )
 
-        # Only joint attention (no attn2, no to_add_out for context)
+        # Only joint attention
         self.attn = SD35MediumSelfAttention(
             dim=dim,
             num_heads=num_heads,
@@ -521,13 +511,13 @@ class JointTransformerBlockFinal(Module):
             eps=eps,
             mesh_device=mesh_device,
             added_proj_dim=dim,
-            context_pre_only=True,  # Final block: no to_add_out for context
+            context_pre_only=True,
         )
 
-        # Post-attention normalization (only for x)
+        # Post-attention normalization
         self.norm2 = LayerNorm(dim, norm_eps=eps, norm_elementwise_affine=False, mesh_device=mesh_device)
 
-        # Feed forward network (only for x, no ff_context)
+        # Feed forward network
         self.ff = FeedForward(dim=dim, hidden_dim=6144, mesh_device=mesh_device)
 
     def forward(self, x, context, conditioning, seq_len, context_seq_len):
@@ -546,7 +536,7 @@ class JointTransformerBlockFinal(Module):
         x_norm, x_scale = self.norm1(x, conditioning)
         context_norm, context_scale = self.norm1_context(context, conditioning)
 
-        # Extract x modulation params (6 total for AdaLayerNormZero)
+        # Extract x modulation params
         x_shift_msa = x_scale[:, :, 0:1, :]
         x_scale_msa = x_scale[:, :, 1:2, :]
         x_gate_msa = x_scale[:, :, 2:3, :]
@@ -554,7 +544,7 @@ class JointTransformerBlockFinal(Module):
         x_scale_mlp = x_scale[:, :, 4:5, :]
         x_gate_mlp = x_scale[:, :, 5:6, :]
 
-        # Extract context modulation params (2 total for AdaLayerNormContinuous)
+        # Extract context modulation params
         c_shift = context_scale[:, :, 0:1, :]
         c_scale = context_scale[:, :, 1:2, :]
 
@@ -562,17 +552,17 @@ class JointTransformerBlockFinal(Module):
         x_modulated = x_norm * (1 + x_scale_msa) + x_shift_msa
         context_modulated = context_norm * (1 + c_scale) + c_shift
 
-        # Joint attention - note: final block doesn't have to_add_out for context
+        # Joint attention
         attn_out, context_attn_out = self.attn(
             x_modulated, seq_len, added_input=context_modulated, added_seq_len=context_seq_len
         )
 
-        # Apply gate and residual for x (context has no gate in final block)
+        # Apply gate and residual for x
         x = x + x_gate_msa * attn_out
-        # Context: just residual, no gate (AdaLayerNormContinuous has no gate)
+        # Context: just residual, no gate
         context = context + context_attn_out
 
-        # Feed forward (only for x)
+        # Feed forward
         x_norm_ff = self.norm2(x)
         x_modulated_ff = x_norm_ff * (1 + x_scale_mlp) + x_shift_mlp
         ff_out = self.ff(x_modulated_ff)
@@ -584,7 +574,6 @@ class JointTransformerBlockFinal(Module):
         """Load weights from PyTorch state dict."""
         self.norm1.load_torch_state_dict(substate(state_dict, "norm1"))
         self.norm1_context.load_torch_state_dict(substate(state_dict, "norm1_context"))
-        # norm2 has norm_elementwise_affine=False, no weights to load
         self.attn.load_state_dict(substate(state_dict, "attn"))
         # NOTE: Final block does NOT have attn2
         self.ff.load_torch_state_dict(substate(state_dict, "ff"))

--- a/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
@@ -221,7 +221,7 @@ class AdaLayerNormContinuousOutput(Module):
         """
         Args:
             x: Input tensor [1, B, seq_len, hidden_size]
-            c: Conditioning tensor [1, B, 1, hidden_size] (temb)
+            c: Conditioning tensor [1, B, 1, hidden_size] or [1, 1, B, 1, hidden_size] when guidance_cond=2 (temb)
         Returns:
             Modulated tensor [1, B, seq_len, hidden_size]
         """
@@ -232,8 +232,25 @@ class AdaLayerNormContinuousOutput(Module):
         c_silu = ttnn.silu(c)
         emb = self.linear(c_silu)
 
+        # Handle different input shapes for guidance_cond=2
+        # Get batch dimension from the appropriate axis
+        if len(emb.shape) == 5:
+            # Shape is [1, 1, B, 1, conditioning_size] - use shape[2] for batch
+            batch_dim = emb.shape[2]
+        elif len(emb.shape) == 4:
+            # Could be [1, B, 1, conditioning_size] or [1, 1, B, conditioning_size]
+            if emb.shape[1] == 1 and emb.shape[2] > 1:
+                # Shape is [1, 1, B, conditioning_size] - use shape[2] for batch (guidance_cond=2)
+                batch_dim = emb.shape[2]
+            else:
+                # Shape is [1, B, 1, conditioning_size] - use shape[1] for batch
+                batch_dim = emb.shape[1]
+        else:
+            # Shape is [1, B, conditioning_size] - use shape[1] for batch
+            batch_dim = emb.shape[1]
+
         # Reshape to [1, B, 2, hidden_size] for chunking
-        emb = ttnn.reshape(emb, (1, emb.shape[1], 2, self.hidden_size))
+        emb = ttnn.reshape(emb, (1, batch_dim, 2, self.hidden_size))
 
         # Extract scale and shift
         scale = emb[:, :, 0:1, :]

--- a/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
@@ -9,7 +9,6 @@ from models.experimental.tt_dit.layers.linear import Linear
 from models.experimental.tt_dit.layers.normalization import LayerNorm
 from models.experimental.tt_dit.utils.substate import substate
 
-# Import working implementations from embeddings
 from models.experimental.tt_dit.layers.embeddings import (
     SD35CombinedTimestepTextProjEmbeddings,
 )
@@ -184,13 +183,6 @@ class AdaLayerNormContinuousOutput(Module):
     """
     AdaLayerNormContinuous for norm_out - applies modulation directly.
 
-    Diffusers implementation:
-    ```python
-    emb = self.linear(self.silu(conditioning))
-    scale, shift = emb.chunk(2, dim=-1)  # NOTE: scale first, then shift!
-    x = self.norm(x) * (1 + scale) + shift
-    return x  # Returns modulated tensor directly
-    ```
     """
 
     def __init__(

--- a/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
@@ -1,0 +1,549 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SD3Transformer2DModel implementation for SD3.5 Medium
+"""
+
+import math
+import torch
+import ttnn
+from models.experimental.tt_dit.layers.module import Module, Parameter
+from models.experimental.tt_dit.layers.linear import Linear
+from models.experimental.tt_dit.layers.normalization import LayerNorm
+from models.experimental.tt_dit.utils.substate import substate
+
+# Import working implementations from embeddings
+from models.experimental.tt_dit.layers.embeddings import (
+    SD35CombinedTimestepTextProjEmbeddings,
+)
+
+
+class SD35PatchEmbed(Module):
+    """
+    Custom PatchEmbed for SD3.5 Medium that handles 4D output tensors properly.
+    Converts image latents to patch embeddings with positional encoding.
+    Supports dynamic input sizes by cropping pos_embed at runtime.
+    """
+
+    def __init__(
+        self,
+        height,
+        width,
+        patch_size,
+        in_channels,
+        embed_dim,
+        pos_embed_max_size,
+        mesh_device=None,
+    ):
+        super().__init__()
+
+        self.height = height // patch_size  # Max height in patches
+        self.width = width // patch_size  # Max width in patches
+        self.patch_size = patch_size
+        self.in_channels = in_channels
+        self.embed_dim = embed_dim
+        self.pos_embed_max_size = pos_embed_max_size
+        self.mesh_device = mesh_device
+
+        # Compute kernel config for linear operations
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+
+        # Projection weights (equivalent to conv2d)
+        self.proj_weight = Parameter(
+            total_shape=[in_channels * patch_size * patch_size, embed_dim],
+            mesh_axes=[None, None],
+            device=mesh_device,
+        )
+        self.proj_bias = Parameter(
+            total_shape=[1, 1, 1, embed_dim],
+            mesh_axes=[None, None, None, None],
+            device=mesh_device,
+        )
+
+        # Position embeddings - store at max size [1, 1, max_seq_len, embed_dim]
+        # Will be cropped at runtime based on actual input size
+        max_seq_len = self.height * self.width
+        self.pos_embed = Parameter(
+            total_shape=[1, 1, max_seq_len, embed_dim],
+            device=mesh_device,
+            mesh_axes=[None, None, None, None],
+        )
+
+        # Store the torch pos_embed for runtime cropping
+        self._torch_pos_embed = None
+
+    def _cropped_pos_embed_torch(self, pos_embed_param, target_height, target_width):
+        """Crop position embeddings from max size to target size (torch tensor)."""
+        pos_embed_max_size = math.isqrt(pos_embed_param.shape[1])
+        top = (pos_embed_max_size - target_height) // 2
+        left = (pos_embed_max_size - target_width) // 2
+
+        spatial_pos_embed = pos_embed_param.reshape([1, pos_embed_max_size, pos_embed_max_size, -1])
+        spatial_pos_embed = spatial_pos_embed[:, top : top + target_height, left : left + target_width, :]
+        spatial_pos_embed = spatial_pos_embed.reshape([1, 1, -1, spatial_pos_embed.shape[-1]])
+
+        return spatial_pos_embed
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        """Prepare PyTorch state dict for loading."""
+        conv_weight = state.pop("proj.weight", None)
+        if conv_weight is not None:
+            # Convert from (out_channels, in_channels, kh, kw) to (kh*kw*in_channels, out_channels)
+            out_channels, in_c, kh, kw = conv_weight.shape
+            conv_weight = conv_weight.permute(2, 3, 1, 0)  # (kh, kw, in_c, out_channels)
+            conv_weight = conv_weight.reshape(kh * kw * in_c, out_channels)
+            state["proj_weight"] = conv_weight
+
+        if "proj.bias" in state:
+            state["proj_bias"] = state.pop("proj.bias").reshape(1, 1, 1, -1)
+
+        if "pos_embed" in state:
+            # Store original pos_embed for runtime cropping
+            self._torch_pos_embed = state["pos_embed"].clone()
+            # Crop for default size
+            state["pos_embed"] = self._cropped_pos_embed_torch(state.pop("pos_embed"), self.height, self.width)
+
+    def forward(self, latent: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Forward pass: apply patch projection and add position embeddings.
+
+        Args:
+            latent: Input tensor of shape (batch_size, height, width, channels) in NHWC format
+
+        Returns:
+            Patch embeddings of shape (1, batch_size, num_patches, embed_dim)
+        """
+        batch_size, img_h, img_w, img_c = latent.shape
+        patches_h = img_h // self.patch_size
+        patches_w = img_w // self.patch_size
+
+        latent = self._unfold_conv2d(latent)
+
+        # Check if we need to use different pos_embed size
+        actual_seq_len = patches_h * patches_w
+        stored_seq_len = self.pos_embed.data.shape[2]
+
+        if actual_seq_len != stored_seq_len and self._torch_pos_embed is not None:
+            # Crop pos_embed to match actual input size
+            cropped_pos_embed = self._cropped_pos_embed_torch(self._torch_pos_embed, patches_h, patches_w)
+            pos_embed_tensor = ttnn.from_torch(
+                cropped_pos_embed,
+                dtype=ttnn.bfloat16,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            return latent + pos_embed_tensor
+        else:
+            return latent + self.pos_embed.data
+
+    def _unfold_conv2d(self, x):
+        """
+        Unfold conv2d operation: reshape patches and apply linear transformation.
+
+        Args:
+            x: Input tensor (batch_size, height, width, channels)
+
+        Returns:
+            Projected tensor (1, batch_size, patches_h * patches_w, embed_dim)
+        """
+        batch_size, img_h, img_w, img_c = x.shape
+
+        patches_h = img_h // self.patch_size
+        patches_w = img_w // self.patch_size
+
+        # Reshape input to extract patches
+        # (batch_size, patches_h, patch_size, patches_w, patch_size, img_c)
+        x = ttnn.reshape(x, (batch_size, patches_h, self.patch_size, patches_w, self.patch_size, img_c))
+
+        # Permute to group patch dimensions together
+        # (batch_size, patches_h, patches_w, patch_size, patch_size, img_c)
+        x = ttnn.permute(x, (0, 1, 3, 2, 4, 5))
+
+        # Flatten patch dimensions
+        # (batch_size, patches_h * patches_w, patch_size * patch_size * img_c)
+        x = ttnn.reshape(x, (batch_size, patches_h * patches_w, self.patch_size * self.patch_size * img_c))
+
+        # Apply linear projection (equivalent to conv2d)
+        out = ttnn.linear(
+            x,
+            self.proj_weight.data,
+            bias=self.proj_bias.data,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=self.compute_kernel_config,
+        )
+
+        out = ttnn.reshape(out, (1, batch_size, patches_h * patches_w, -1))
+        return out
+
+
+# Import JointTransformerBlock implementations
+from models.experimental.tt_dit.models.transformers.sd35_med.joint_block_sd35_medium import (
+    JointTransformerBlockEarly,
+    JointTransformerBlockMiddle,
+    JointTransformerBlockFinal,
+)
+
+
+class AdaLayerNormContinuousOutput(Module):
+    """
+    AdaLayerNormContinuous for norm_out - applies modulation directly.
+
+    Diffusers implementation:
+    ```python
+    emb = self.linear(self.silu(conditioning))
+    scale, shift = emb.chunk(2, dim=-1)  # NOTE: scale first, then shift!
+    x = self.norm(x) * (1 + scale) + shift
+    return x  # Returns modulated tensor directly
+    ```
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        conditioning_size: int,
+        bias: bool = True,
+        mesh_device=None,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.conditioning_size = conditioning_size
+        self.mesh_device = mesh_device
+
+        # Linear layer: hidden_size -> conditioning_size (2 * hidden_size)
+        self.linear = Linear(hidden_size, conditioning_size, bias=bias, mesh_device=mesh_device)
+
+        # Layer norm (no learnable params)
+        self.norm = LayerNorm(
+            hidden_size,
+            norm_eps=eps,
+            norm_elementwise_affine=False,
+            mesh_device=mesh_device,
+        )
+
+    def forward(self, x, c):
+        """
+        Args:
+            x: Input tensor [1, B, seq_len, hidden_size]
+            c: Conditioning tensor [1, B, 1, hidden_size] (temb)
+        Returns:
+            Modulated tensor [1, B, seq_len, hidden_size]
+        """
+        # Apply layer norm
+        x_norm = self.norm(x)
+
+        # Process conditioning: SiLU FIRST, then linear (matching Diffusers)
+        c_silu = ttnn.silu(c)
+        emb = self.linear(c_silu)
+
+        # Reshape to [1, B, 2, hidden_size] for chunking
+        emb = ttnn.reshape(emb, (1, emb.shape[1], 2, self.hidden_size))
+
+        # Extract scale and shift - Diffusers: scale, shift = emb.chunk(2)
+        # So index 0 = scale, index 1 = shift
+        scale = emb[:, :, 0:1, :]
+        shift = emb[:, :, 1:2, :]
+
+        # Apply modulation: x = norm(x) * (1 + scale) + shift
+        x_out = x_norm * (1 + scale) + shift
+
+        return x_out
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict."""
+        self.linear.load_torch_state_dict(substate(state_dict, "linear"))
+
+
+# =============================================================================
+# Main Transformer Model
+# =============================================================================
+
+
+class SD3Transformer2DModel(Module):
+    """SD3Transformer2DModel for SD3.5 Medium with 24 transformer blocks"""
+
+    def __init__(
+        self,
+        sample_size: int = 128,
+        patch_size: int = 2,
+        in_channels: int = 16,
+        num_layers: int = 24,
+        attention_head_dim: int = 64,
+        num_attention_heads: int = 24,
+        joint_attention_dim: int = 4096,
+        caption_projection_dim: int = 2432,
+        pooled_projection_dim: int = 2048,
+        out_channels: int = 16,
+        pos_embed_max_size: int = 192,
+        mesh_device=None,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.sample_size = sample_size
+        self.patch_size = patch_size
+        self.in_channels = in_channels
+        self.num_layers = num_layers
+        self.attention_head_dim = attention_head_dim
+        self.num_attention_heads = num_attention_heads
+        self.joint_attention_dim = joint_attention_dim
+        self.caption_projection_dim = caption_projection_dim
+        self.pooled_projection_dim = pooled_projection_dim
+        self.out_channels = out_channels
+        self.pos_embed_max_size = pos_embed_max_size
+        self.mesh_device = mesh_device
+
+        # Calculate hidden dimension
+        self.inner_dim = num_attention_heads * attention_head_dim
+
+        # Positional embedding (patch embedding) - use custom SD35PatchEmbed
+        self.pos_embed = SD35PatchEmbed(
+            height=sample_size,
+            width=sample_size,
+            patch_size=patch_size,
+            in_channels=in_channels,
+            embed_dim=self.inner_dim,
+            pos_embed_max_size=pos_embed_max_size,
+            mesh_device=mesh_device,
+        )
+
+        # Time and text embedding - use imported working version
+        self.time_text_embed = SD35CombinedTimestepTextProjEmbeddings(
+            embedding_dim=self.inner_dim,
+            pooled_projection_dim=pooled_projection_dim,
+            mesh_device=mesh_device,
+        )
+
+        # Context embedder
+        self.context_embedder = Linear(
+            in_features=joint_attention_dim,
+            out_features=self.inner_dim,
+            bias=True,
+            mesh_device=mesh_device,
+        )
+
+        # Transformer blocks
+        self.transformer_blocks = []
+
+        # Blocks 0-12: Early blocks with SD35AdaLayerNormZeroX + AdaLayerNormZero
+        for i in range(13):
+            block = JointTransformerBlockEarly(
+                dim=self.inner_dim,
+                num_heads=num_attention_heads,
+                mesh_device=mesh_device,
+                eps=eps,
+            )
+            self.transformer_blocks.append(block)
+
+        # Blocks 13-22: Middle blocks with AdaLayerNormZero + AdaLayerNormZero
+        for i in range(10):
+            block = JointTransformerBlockMiddle(
+                dim=self.inner_dim,
+                num_heads=num_attention_heads,
+                mesh_device=mesh_device,
+                eps=eps,
+            )
+            self.transformer_blocks.append(block)
+
+        # Block 23: Final block with AdaLayerNormZero + AdaLayerNormContinuous
+        block = JointTransformerBlockFinal(
+            dim=self.inner_dim,
+            num_heads=num_attention_heads,
+            mesh_device=mesh_device,
+            eps=eps,
+        )
+        self.transformer_blocks.append(block)
+
+        # Output normalization - use inlined version with correct scale/shift order
+        self.norm_out = AdaLayerNormContinuousOutput(
+            hidden_size=self.inner_dim,
+            conditioning_size=self.inner_dim * 2,  # 2x for scale and shift
+            bias=True,
+            mesh_device=mesh_device,
+            eps=eps,
+        )
+
+        self.proj_out = Linear(
+            in_features=self.inner_dim,
+            out_features=out_channels * patch_size * patch_size,
+            bias=True,
+            mesh_device=mesh_device,
+        )
+
+        # Compute kernel config for attention
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+        self.core_grid = mesh_device.compute_with_storage_grid_size()
+
+    def forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        encoder_hidden_states: ttnn.Tensor,
+        timestep: ttnn.Tensor,
+        pooled_projection: ttnn.Tensor,
+        seq_len: int,
+        context_seq_len: int,
+    ):
+        """
+        Forward pass of SD3Transformer2DModel
+
+        Args:
+            hidden_states: Input latent tensor [B, H, W, C] NHWC format
+            encoder_hidden_states: Text encoder output [B, context_seq_len, joint_attention_dim]
+            timestep: Timestep tensor [B, 1]
+            pooled_projection: Pooled text projection [1, 1, B, pooled_projection_dim]
+            seq_len: Sequence length for hidden states
+            context_seq_len: Sequence length for context
+
+        Returns:
+            Output latent tensor [1, B, seq_len, out_channels*patch_size^2]
+        """
+        # Apply positional embedding (also handles patchify)
+        hidden_states = self.pos_embed(hidden_states)
+
+        # Add batch dimension for TTNN convention [1, B, seq_len, dim]
+        if hidden_states.shape[0] != 1 or len(hidden_states.shape) == 3:
+            hidden_states = ttnn.reshape(
+                hidden_states, (1, hidden_states.shape[0], hidden_states.shape[1], hidden_states.shape[2])
+            )
+
+        # Compute time and text embeddings
+        temb = self.time_text_embed(timestep, pooled_projection)
+
+        # Embed context
+        context = self.context_embedder(encoder_hidden_states)
+
+        # Add batch dimension for context if needed
+        if len(context.shape) == 3:
+            context = ttnn.reshape(context, (1, context.shape[0], context.shape[1], context.shape[2]))
+
+        # Pass through transformer blocks
+        for block in self.transformer_blocks:
+            hidden_states, context = block(
+                x=hidden_states,
+                context=context,
+                conditioning=temb,
+                seq_len=seq_len,
+                context_seq_len=context_seq_len,
+            )
+
+        # Apply output normalization (applies modulation internally)
+        hidden_states = self.norm_out(hidden_states, temb)
+
+        # Final projection
+        output = self.proj_out(hidden_states)
+
+        return output
+
+    def unpatchify(self, x, height, width):
+        """
+        Unpatchify the output tensor from [B, seq_len, patch_size^2 * out_channels]
+        to [B, out_channels, height, width]
+
+        This matches Diffusers' _get_output_for_patched_inputs which uses:
+        output = hidden_states.reshape(batch_size, height, width, p, p, out_channels)
+        output = output.permute(0, 5, 1, 3, 2, 4).reshape(batch_size, out_channels, height*p, width*p)
+
+        Args:
+            x: Tensor of shape [B, seq_len, patch_size^2 * out_channels] or [1, B, seq_len, ...]
+            height: Output height in latent space (before VAE upscaling)
+            width: Output width in latent space (before VAE upscaling)
+
+        Returns:
+            Tensor of shape [B, out_channels, height, width]
+        """
+        import torch
+
+        # Handle TTNN tensor
+        if hasattr(x, "shape") and not isinstance(x, torch.Tensor):
+            x = ttnn.to_torch(ttnn.from_device(x))
+
+        # Remove extra dimensions
+        while x.dim() > 3:
+            x = x.squeeze(0)
+
+        batch_size = x.shape[0]
+        p = self.patch_size
+        c = self.out_channels
+        h = height // p
+        w = width // p
+
+        # Diffusers order: features are [p * p * c] -> reshape to [p, p, c]
+        # Reshape: [B, h*w, p*p*c] -> [B, h, w, p, p, c]
+        x = x.reshape(batch_size, h, w, p, p, c)
+
+        # Permute: [B, h, w, p, p, c] -> [B, c, h, p, w, p]
+        x = x.permute(0, 5, 1, 3, 2, 4)
+
+        # Reshape: [B, c, h, p, w, p] -> [B, c, h*p, w*p]
+        x = x.reshape(batch_size, c, h * p, w * p)
+
+        return x
+
+    def load_torch_state_dict(self, state_dict):
+        """Load weights from PyTorch state dict"""
+        # Load positional embedding
+        self.pos_embed.load_torch_state_dict(substate(state_dict, "pos_embed"))
+
+        # Load time and text embeddings
+        self.time_text_embed.load_torch_state_dict(substate(state_dict, "time_text_embed"))
+
+        # Load context embedder
+        self.context_embedder.load_torch_state_dict(substate(state_dict, "context_embedder"))
+
+        # Load transformer blocks
+        for i, block in enumerate(self.transformer_blocks):
+            block.load_torch_state_dict(substate(state_dict, f"transformer_blocks.{i}"))
+
+        # Load output layers
+        self.norm_out.load_torch_state_dict(substate(state_dict, "norm_out"))
+        self.proj_out.load_torch_state_dict(substate(state_dict, "proj_out"))
+
+    def to_cached_state_dict(self, path_prefix):
+        """Create cached state dict for faster loading"""
+        cache_dict = {}
+
+        # Cache positional embedding
+        pos_embed_cache = self.pos_embed.to_cached_state_dict(path_prefix + "pos_embed.")
+        for key, value in pos_embed_cache.items():
+            cache_dict[f"pos_embed.{key}"] = value
+
+        # Cache time and text embeddings
+        time_text_cache = self.time_text_embed.to_cached_state_dict(path_prefix + "time_text_embed.")
+        for key, value in time_text_cache.items():
+            cache_dict[f"time_text_embed.{key}"] = value
+
+        # Cache context embedder
+        context_cache = self.context_embedder.to_cached_state_dict(path_prefix + "context_embedder.")
+        for key, value in context_cache.items():
+            cache_dict[f"context_embedder.{key}"] = value
+
+        # Cache transformer blocks
+        for i, block in enumerate(self.transformer_blocks):
+            block_cache = block.to_cached_state_dict(path_prefix + f"transformer_blocks.{i}.")
+            for key, value in block_cache.items():
+                cache_dict[f"transformer_blocks.{i}.{key}"] = value
+
+        # Cache output layers
+        norm_out_cache = self.norm_out.to_cached_state_dict(path_prefix + "norm_out.")
+        proj_out_cache = self.proj_out.to_cached_state_dict(path_prefix + "proj_out.")
+
+        for key, value in norm_out_cache.items():
+            cache_dict[f"norm_out.{key}"] = value
+        for key, value in proj_out_cache.items():
+            cache_dict[f"proj_out.{key}"] = value
+
+        return cache_dict

--- a/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
+++ b/models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
@@ -1,9 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-
-"""
-SD3Transformer2DModel implementation for SD3.5 Medium
-"""
 
 import math
 import torch
@@ -16,6 +12,11 @@ from models.experimental.tt_dit.utils.substate import substate
 # Import working implementations from embeddings
 from models.experimental.tt_dit.layers.embeddings import (
     SD35CombinedTimestepTextProjEmbeddings,
+)
+from models.experimental.tt_dit.models.transformers.sd35_med.joint_block_sd35_medium import (
+    JointTransformerBlockEarly,
+    JointTransformerBlockMiddle,
+    JointTransformerBlockFinal,
 )
 
 
@@ -38,8 +39,8 @@ class SD35PatchEmbed(Module):
     ):
         super().__init__()
 
-        self.height = height // patch_size  # Max height in patches
-        self.width = width // patch_size  # Max width in patches
+        self.height = height // patch_size
+        self.width = width // patch_size
         self.patch_size = patch_size
         self.in_channels = in_channels
         self.embed_dim = embed_dim
@@ -55,7 +56,7 @@ class SD35PatchEmbed(Module):
             packer_l1_acc=False,
         )
 
-        # Projection weights (equivalent to conv2d)
+        # Projection weights
         self.proj_weight = Parameter(
             total_shape=[in_channels * patch_size * patch_size, embed_dim],
             mesh_axes=[None, None],
@@ -67,8 +68,7 @@ class SD35PatchEmbed(Module):
             device=mesh_device,
         )
 
-        # Position embeddings - store at max size [1, 1, max_seq_len, embed_dim]
-        # Will be cropped at runtime based on actual input size
+        # Position embeddings
         max_seq_len = self.height * self.width
         self.pos_embed = Parameter(
             total_shape=[1, 1, max_seq_len, embed_dim],
@@ -95,9 +95,8 @@ class SD35PatchEmbed(Module):
         """Prepare PyTorch state dict for loading."""
         conv_weight = state.pop("proj.weight", None)
         if conv_weight is not None:
-            # Convert from (out_channels, in_channels, kh, kw) to (kh*kw*in_channels, out_channels)
             out_channels, in_c, kh, kw = conv_weight.shape
-            conv_weight = conv_weight.permute(2, 3, 1, 0)  # (kh, kw, in_c, out_channels)
+            conv_weight = conv_weight.permute(2, 3, 1, 0)
             conv_weight = conv_weight.reshape(kh * kw * in_c, out_channels)
             state["proj_weight"] = conv_weight
 
@@ -160,18 +159,15 @@ class SD35PatchEmbed(Module):
         patches_w = img_w // self.patch_size
 
         # Reshape input to extract patches
-        # (batch_size, patches_h, patch_size, patches_w, patch_size, img_c)
         x = ttnn.reshape(x, (batch_size, patches_h, self.patch_size, patches_w, self.patch_size, img_c))
 
         # Permute to group patch dimensions together
-        # (batch_size, patches_h, patches_w, patch_size, patch_size, img_c)
         x = ttnn.permute(x, (0, 1, 3, 2, 4, 5))
 
         # Flatten patch dimensions
-        # (batch_size, patches_h * patches_w, patch_size * patch_size * img_c)
         x = ttnn.reshape(x, (batch_size, patches_h * patches_w, self.patch_size * self.patch_size * img_c))
 
-        # Apply linear projection (equivalent to conv2d)
+        # Apply linear projection
         out = ttnn.linear(
             x,
             self.proj_weight.data,
@@ -182,14 +178,6 @@ class SD35PatchEmbed(Module):
 
         out = ttnn.reshape(out, (1, batch_size, patches_h * patches_w, -1))
         return out
-
-
-# Import JointTransformerBlock implementations
-from models.experimental.tt_dit.models.transformers.sd35_med.joint_block_sd35_medium import (
-    JointTransformerBlockEarly,
-    JointTransformerBlockMiddle,
-    JointTransformerBlockFinal,
-)
 
 
 class AdaLayerNormContinuousOutput(Module):
@@ -247,12 +235,11 @@ class AdaLayerNormContinuousOutput(Module):
         # Reshape to [1, B, 2, hidden_size] for chunking
         emb = ttnn.reshape(emb, (1, emb.shape[1], 2, self.hidden_size))
 
-        # Extract scale and shift - Diffusers: scale, shift = emb.chunk(2)
-        # So index 0 = scale, index 1 = shift
+        # Extract scale and shift
         scale = emb[:, :, 0:1, :]
         shift = emb[:, :, 1:2, :]
 
-        # Apply modulation: x = norm(x) * (1 + scale) + shift
+        # Apply modulation
         x_out = x_norm * (1 + scale) + shift
 
         return x_out
@@ -260,11 +247,6 @@ class AdaLayerNormContinuousOutput(Module):
     def load_torch_state_dict(self, state_dict):
         """Load weights from PyTorch state dict."""
         self.linear.load_torch_state_dict(substate(state_dict, "linear"))
-
-
-# =============================================================================
-# Main Transformer Model
-# =============================================================================
 
 
 class SD3Transformer2DModel(Module):
@@ -303,7 +285,7 @@ class SD3Transformer2DModel(Module):
         # Calculate hidden dimension
         self.inner_dim = num_attention_heads * attention_head_dim
 
-        # Positional embedding (patch embedding) - use custom SD35PatchEmbed
+        # Positional embedding (patch embedding)
         self.pos_embed = SD35PatchEmbed(
             height=sample_size,
             width=sample_size,
@@ -314,7 +296,7 @@ class SD3Transformer2DModel(Module):
             mesh_device=mesh_device,
         )
 
-        # Time and text embedding - use imported working version
+        # Time and text embedding
         self.time_text_embed = SD35CombinedTimestepTextProjEmbeddings(
             embedding_dim=self.inner_dim,
             pooled_projection_dim=pooled_projection_dim,
@@ -361,10 +343,10 @@ class SD3Transformer2DModel(Module):
         )
         self.transformer_blocks.append(block)
 
-        # Output normalization - use inlined version with correct scale/shift order
+        # Output normalization
         self.norm_out = AdaLayerNormContinuousOutput(
             hidden_size=self.inner_dim,
-            conditioning_size=self.inner_dim * 2,  # 2x for scale and shift
+            conditioning_size=self.inner_dim * 2,
             bias=True,
             mesh_device=mesh_device,
             eps=eps,
@@ -411,10 +393,10 @@ class SD3Transformer2DModel(Module):
         Returns:
             Output latent tensor [1, B, seq_len, out_channels*patch_size^2]
         """
-        # Apply positional embedding (also handles patchify)
+        # Apply positional embedding
         hidden_states = self.pos_embed(hidden_states)
 
-        # Add batch dimension for TTNN convention [1, B, seq_len, dim]
+        # Add batch dimension
         if hidden_states.shape[0] != 1 or len(hidden_states.shape) == 3:
             hidden_states = ttnn.reshape(
                 hidden_states, (1, hidden_states.shape[0], hidden_states.shape[1], hidden_states.shape[2])
@@ -426,7 +408,7 @@ class SD3Transformer2DModel(Module):
         # Embed context
         context = self.context_embedder(encoder_hidden_states)
 
-        # Add batch dimension for context if needed
+        # Add batch dimension
         if len(context.shape) == 3:
             context = ttnn.reshape(context, (1, context.shape[0], context.shape[1], context.shape[2]))
 
@@ -440,7 +422,7 @@ class SD3Transformer2DModel(Module):
                 context_seq_len=context_seq_len,
             )
 
-        # Apply output normalization (applies modulation internally)
+        # Apply output normalization
         hidden_states = self.norm_out(hidden_states, temb)
 
         # Final projection
@@ -481,14 +463,13 @@ class SD3Transformer2DModel(Module):
         h = height // p
         w = width // p
 
-        # Diffusers order: features are [p * p * c] -> reshape to [p, p, c]
-        # Reshape: [B, h*w, p*p*c] -> [B, h, w, p, p, c]
+        # Reshape
         x = x.reshape(batch_size, h, w, p, p, c)
 
-        # Permute: [B, h, w, p, p, c] -> [B, c, h, p, w, p]
+        # Permute
         x = x.permute(0, 5, 1, 3, 2, 4)
 
-        # Reshape: [B, c, h, p, w, p] -> [B, c, h*p, w*p]
+        # Reshape
         x = x.reshape(batch_size, c, h * p, w * p)
 
         return x

--- a/models/experimental/tt_dit/models/vae/vae_sd35_med.py
+++ b/models/experimental/tt_dit/models/vae/vae_sd35_med.py
@@ -1,0 +1,688 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import ttnn
+
+from models.tt_cnn.tt.builder import TtConv2d, Conv2dConfiguration
+from ...layers.normalization import GroupNorm
+from ...layers.linear import ColParallelLinear, Linear
+from ...utils.substate import substate, indexed_substates
+from ...parallel.config import vae_all_gather
+
+if TYPE_CHECKING:
+    pass
+
+
+class Conv2d:
+    """
+    Wrapper around TtConv2d from builder.py that provides initialization with input dimensions.
+    TtConv2d requires input dimensions at construction time, but we may not know
+    them until the first forward call. This class stores the configuration and
+    creates the TtConv2d with input dimensions.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        mesh_device=None,
+        out_mesh_axis=None,
+        ccl_manager=None,
+        torch_ref=None,
+    ):
+        self.in_channels = in_channels if torch_ref is None else torch_ref.in_channels
+        self.out_channels = out_channels if torch_ref is None else torch_ref.out_channels
+        self.kernel_size = kernel_size if torch_ref is None else torch_ref.kernel_size
+        self.stride = stride if torch_ref is None else torch_ref.stride
+        self.padding = padding if torch_ref is None else torch_ref.padding
+        self.mesh_device = mesh_device
+        self.out_mesh_axis = out_mesh_axis
+        self.ccl_manager = ccl_manager
+        self.torch_ref = torch_ref
+
+        # Normalize to tuples
+        if isinstance(self.kernel_size, int):
+            self.kernel_size = (self.kernel_size, self.kernel_size)
+        if isinstance(self.stride, int):
+            self.stride = (self.stride, self.stride)
+        if isinstance(self.padding, int):
+            self.padding = (self.padding, self.padding)
+
+        # Weight and bias from torch_ref or to be loaded later
+        self.weight_torch = None
+        self.bias_torch = None
+        if torch_ref is not None:
+            self.weight_torch = torch_ref.weight.data
+            self.bias_torch = torch_ref.bias.data if torch_ref.bias is not None else None
+
+        # TtConv2d instance (created on first forward call)
+        self._tt_conv2d = None
+        self._last_input_shape = None
+
+    @classmethod
+    def from_torch(cls, torch_ref, mesh_device=None, out_mesh_axis=None, ccl_manager=None):
+        return cls(
+            in_channels=torch_ref.in_channels,
+            out_channels=torch_ref.out_channels,
+            kernel_size=torch_ref.kernel_size,
+            stride=torch_ref.stride,
+            padding=torch_ref.padding,
+            mesh_device=mesh_device,
+            out_mesh_axis=out_mesh_axis,
+            ccl_manager=ccl_manager,
+            torch_ref=torch_ref,
+        )
+
+    def load_torch_state_dict(self, state_dict):
+        self.weight_torch = state_dict["weight"]
+        if "bias" in state_dict:
+            self.bias_torch = state_dict["bias"]
+        # Reset the TtConv2d so it gets recreated with new weights
+        self._tt_conv2d = None
+
+    def _create_tt_conv2d(self, batch_size, input_height, input_width):
+        """Create the TtConv2d instance with the given input dimensions."""
+        if self.weight_torch is None:
+            raise RuntimeError("Weights not loaded. Call load_torch_state_dict first.")
+
+        # Get the device from mesh_device
+        device = self.mesh_device
+
+        # Create mesh_mapper if using mesh parallelism
+        mesh_mapper = None
+        if self.out_mesh_axis is not None and self.mesh_device is not None:
+            mesh_mapper = ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=(self.out_mesh_axis, None),
+                mesh_shape=self.mesh_device.shape,
+            )
+
+        # Convert weights and bias to ttnn tensors
+        weight, bias = Conv2dConfiguration.convert_torch_weight_and_bias_to_ttnn(
+            self.weight_torch,
+            self.bias_torch,
+            mesh_mapper=mesh_mapper,
+        )
+
+        config = Conv2dConfiguration(
+            input_height=input_height,
+            input_width=input_width,
+            in_channels=self.in_channels,
+            out_channels=self.out_channels,
+            batch_size=batch_size,
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            weight=weight,
+            bias=bias,
+        )
+
+        self._tt_conv2d = TtConv2d(config, device)
+        self._last_input_shape = (batch_size, input_height, input_width)
+
+    def __call__(self, x):
+        b, h, w, c = x.shape
+
+        # Create or recreate TtConv2d if input shape changed
+        if self._tt_conv2d is None or self._last_input_shape != (b, h, w):
+            self._create_tt_conv2d(b, h, w)
+
+        # TtConv2d returns flattened output, need to reshape to (b, out_height, out_width, channels)
+        x, (out_height, out_width) = self._tt_conv2d(x, return_output_dim=True)
+        x = ttnn.reshape(x, (b, out_height, out_width, -1))
+        return x
+
+
+class ResnetBlock:
+    def __init__(
+        self,
+        in_channels=None,
+        out_channels=None,
+        num_groups=None,
+        eps=None,
+        mesh_device=None,
+        norm_core_grid=None,
+        parallel_config=None,
+        ccl_manager=None,
+        torch_ref=None,
+    ):
+        self.norm1 = GroupNorm(
+            num_groups=num_groups,
+            num_channels=in_channels,
+            eps=eps,
+            mesh_device=mesh_device,
+            mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            core_grid=norm_core_grid,
+            torch_ref=torch_ref.norm1 if torch_ref is not None else None,
+        )
+        self.norm2 = GroupNorm(
+            num_groups=num_groups,
+            num_channels=out_channels,
+            eps=eps,
+            mesh_device=mesh_device,
+            mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            core_grid=norm_core_grid,
+            torch_ref=torch_ref.norm2 if torch_ref is not None else None,
+        )
+        self.conv1 = Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=(3, 3),
+            mesh_device=mesh_device,
+            out_mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            ccl_manager=ccl_manager,
+            torch_ref=torch_ref.conv1 if torch_ref is not None else None,
+        )
+        self.conv2 = Conv2d(
+            out_channels,
+            out_channels,
+            kernel_size=(3, 3),
+            mesh_device=mesh_device,
+            out_mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            ccl_manager=ccl_manager,
+            torch_ref=torch_ref.conv2 if torch_ref is not None else None,
+        )
+        self.conv_shortcut = None
+        if in_channels != out_channels or torch_ref.conv_shortcut is not None:
+            self.conv_shortcut = Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=(1, 1),
+                padding=(0, 0),
+                mesh_device=mesh_device,
+                out_mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+                ccl_manager=ccl_manager,
+                torch_ref=torch_ref.conv_shortcut,
+            )
+        else:
+            self.conv_shortcut = None
+
+    def load_torch_state_dict(self, state_dict):
+        self.norm1.load_torch_state_dict(state_dict["norm1"])
+        self.norm2.load_torch_state_dict(state_dict["norm2"])
+        self.conv1.load_torch_state_dict(state_dict["conv1"])
+        self.conv2.load_torch_state_dict(state_dict["conv2"])
+
+        if "conv_shortcut" in state_dict:
+            self.conv_shortcut.load_torch_state_dict(state_dict["conv_shortcut"])
+
+    @classmethod
+    def from_torch(
+        cls,
+        torch_ref,
+        mesh_device=None,
+        norm_core_grid=None,
+        parallel_config=None,
+        ccl_manager=None,
+    ):
+        resnet_block = cls(
+            torch_ref=torch_ref,
+            mesh_device=mesh_device,
+            norm_core_grid=norm_core_grid,
+            parallel_config=parallel_config,
+            ccl_manager=ccl_manager,
+        )
+
+        return resnet_block
+
+    def __call__(self, x):
+        residual = ttnn.clone(x)
+        x = self.norm1(x)
+        x = ttnn.silu(x)
+        x = self.conv1(x)
+        x = self.norm2(x)
+        x = ttnn.silu(x)
+        x = self.conv2(x)
+        if self.conv_shortcut is not None:
+            residual = self.conv_shortcut(residual)
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+        return x + residual
+
+
+class Upsample2D:
+    def __init__(
+        self,
+        in_channels=None,
+        out_channels=None,
+        mesh_device=None,
+        parallel_config=None,
+        ccl_manager=None,
+        torch_ref=None,
+    ):
+        self.conv = Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=(3, 3),
+            mesh_device=mesh_device,
+            out_mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            ccl_manager=ccl_manager,
+            torch_ref=torch_ref.conv if torch_ref is not None else None,
+        )
+
+    # Fix to align with constructor
+    @classmethod
+    def from_torch(cls, torch_ref, mesh_device=None, mesh_axis=None, parallel_manager=None):
+        layer = cls(
+            mesh_device=mesh_device,
+            mesh_axis=mesh_axis,
+            parallel_manager=parallel_manager,
+            torch_ref=torch_ref,
+        )
+        return layer
+
+    def load_torch_state_dict(self, state_dict):
+        self.conv.load_torch_state_dict(state_dict["conv"])
+
+    def __call__(self, x):
+        x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)  # Upsample requires row major.
+        x = ttnn.upsample(x, scale_factor=2)
+        x = self.conv(x)
+        return x
+
+
+class UpDecoderBlock2D:
+    def __init__(
+        self,
+        in_channels=None,
+        out_channels=None,
+        num_layers=None,
+        resnet_groups=None,
+        add_upsample=None,
+        mesh_device=None,
+        norm_core_grid=None,
+        parallel_config=None,
+        ccl_manager=None,
+        torch_ref=None,
+    ):
+        if torch_ref is None:
+            self.resnets = [
+                ResnetBlock(
+                    in_channels=in_channels,
+                    out_channels=out_channels,
+                    num_groups=resnet_groups,
+                    mesh_device=mesh_device,
+                    norm_core_grid=norm_core_grid,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+                for _ in range(num_layers)
+            ]
+            self.upsamplers = (
+                [Upsample2D(in_channels, out_channels, mesh_device, parallel_config, ccl_manager)]
+                if add_upsample
+                else []
+            )
+        else:
+            self.resnets = [
+                ResnetBlock(
+                    torch_ref=resnet,
+                    mesh_device=mesh_device,
+                    norm_core_grid=norm_core_grid,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+                for resnet in torch_ref.resnets
+            ]
+
+            self.upsamplers = [
+                Upsample2D(
+                    torch_ref=upsampler,
+                    mesh_device=mesh_device,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+                for upsampler in torch_ref.upsamplers or []
+            ]
+
+    @classmethod
+    def from_torch(cls, torch_ref, mesh_device=None, norm_core_grid=None, parallel_config=None, ccl_manager=None):
+        layer = cls(
+            torch_ref=torch_ref,
+            mesh_device=mesh_device,
+            norm_core_grid=norm_core_grid,
+            parallel_config=parallel_config,
+            ccl_manager=ccl_manager,
+        )
+        return layer
+
+    # TODO: Fix state dict
+    def load_torch_state_dict(self, state_dict):
+        for i, state in enumerate(indexed_substates(state_dict, "resnets")):
+            self.resnets[i].load_torch_state_dict(state)
+
+        for i, state in enumerate(indexed_substates(state_dict, "upsamplers")):
+            self.upsamplers[i].load_torch_state_dict(state)
+
+    def __call__(self, x):
+        for resnet in self.resnets:
+            x = resnet(x)
+        for upsampler in self.upsamplers:
+            x = upsampler(x)
+        return x
+
+
+# TODO: Add support for coll and row parallel linear. Fuse qkv computation
+class Attention:
+    def __init__(
+        self,
+        query_dim=None,
+        head_dim=None,
+        num_heads=None,
+        norm_num_groups=None,
+        mesh_device=None,
+        parallel_config=None,
+        ccl_manager=None,
+        torch_ref=None,
+    ):
+        self.query_dim = query_dim or torch_ref.to_q.in_features
+        self.num_heads = num_heads or torch_ref.heads
+        self.head_dim = head_dim or torch_ref.to_q.out_features // self.num_heads
+        self.inner_dim = self.head_dim * self.num_heads
+        self.mesh_device = mesh_device
+        self.parallel_config = parallel_config
+        self.ccl_manager = ccl_manager
+        self.to_q = Linear(in_features=self.query_dim, out_features=self.inner_dim, mesh_device=mesh_device)
+        self.to_k = Linear(in_features=self.query_dim, out_features=self.inner_dim, mesh_device=mesh_device)
+        self.to_v = Linear(in_features=self.query_dim, out_features=self.inner_dim, mesh_device=mesh_device)
+        self.to_out = [
+            ColParallelLinear(
+                in_features=self.inner_dim,
+                out_features=self.query_dim,
+                mesh_device=mesh_device,
+                mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            )
+        ]
+        self.group_norm = GroupNorm(
+            num_groups=(norm_num_groups or torch_ref.group_norm.num_groups),
+            num_channels=self.query_dim,
+            eps=torch_ref.group_norm.eps,
+            mesh_device=mesh_device,
+            mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+        )
+
+        if torch_ref is not None:
+            self.load_torch_state_dict(torch_ref.state_dict())
+
+    @classmethod
+    def from_torch(cls, torch_ref, mesh_device=None, parallel_config=None, ccl_manager=None):
+        layer = cls(
+            torch_ref=torch_ref, mesh_device=mesh_device, parallel_config=parallel_config, ccl_manager=ccl_manager
+        )
+        return layer
+
+    @staticmethod
+    def reorder_for_attention(x, batch_size, n_heads, head_dim):
+        return ttnn.permute(ttnn.reshape(x, (batch_size, -1, n_heads, head_dim)), (0, 2, 1, 3))
+
+    def load_torch_state_dict(self, state_dict):
+        self.to_q.load_torch_state_dict(substate(state_dict, "to_q"))
+        self.to_k.load_torch_state_dict(substate(state_dict, "to_k"))
+        self.to_v.load_torch_state_dict(substate(state_dict, "to_v"))
+        for i, state in enumerate(indexed_substates(state_dict, "to_out")):
+            self.to_out[i].load_torch_state_dict(state)
+        self.group_norm.load_torch_state_dict(substate(state_dict, "group_norm"))
+
+    # TODO: Standardize this usage
+    def gather_if_sharded(self, x):
+        if x.shape[3] < self.to_q.in_features:
+            x = vae_all_gather(self.ccl_manager, x, self.parallel_config.tensor_parallel.mesh_axis)
+        return x
+
+    def __call__(self, x):
+        assert len(x.shape) == 4
+        residual = x
+        # elementwise required to be tilized
+        in_layout = x.layout
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+
+        [b, h, w, c] = list(x.shape)
+
+        # No need to transpose like reference. x is alredy channel last
+        x = self.group_norm(x)
+        x = self.gather_if_sharded(x)
+
+        # output will be bxhxwx(num_heads*head_dims)
+        q = self.to_q(x)
+        k = self.to_k(x)
+        v = self.to_v(x)
+        inner_dim = k.shape[-1]
+        head_dim = inner_dim // self.num_heads
+
+        q = self.reorder_for_attention(q, b, self.num_heads, head_dim)
+        k = self.reorder_for_attention(k, b, self.num_heads, head_dim)
+        v = self.reorder_for_attention(v, b, self.num_heads, head_dim)
+
+        x = ttnn.transformer.scaled_dot_product_attention(q, k, v, is_causal=False)
+        x = ttnn.reshape(ttnn.permute(x, (0, 2, 1, 3)), (b, h, w, inner_dim))
+
+        for to_out in self.to_out:
+            x = to_out(x)
+
+        x = x + residual
+
+        x = ttnn.to_layout(x, in_layout)
+        return x
+
+
+class UnetMidBlock2D:
+    def __init__(
+        self,
+        in_channels=None,
+        resnet_groups=None,
+        attention_head_dim=None,
+        mesh_device=None,
+        parallel_config=None,
+        ccl_manager=None,
+        torch_ref=None,
+    ):
+        if torch_ref is None:
+            self.attentions = [
+                Attention(
+                    query_dim=in_channels,
+                    head_dim=attention_head_dim,
+                    num_heads=in_channels // attention_head_dim,
+                    norm_num_groups=resnet_groups,
+                    mesh_device=mesh_device,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+            ]
+            self.resnets = [
+                ResnetBlock(
+                    in_channels=in_channels,
+                    out_channels=in_channels,
+                    num_groups=resnet_groups,
+                    mesh_device=mesh_device,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+                for _ in range(2)
+            ]
+        else:
+            self.attentions = [
+                Attention(
+                    torch_ref=attention,
+                    mesh_device=mesh_device,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+                for attention in torch_ref.attentions
+            ]
+            self.resnets = [
+                ResnetBlock(
+                    torch_ref=resnet, mesh_device=mesh_device, parallel_config=parallel_config, ccl_manager=ccl_manager
+                )
+                for resnet in torch_ref.resnets
+            ]
+
+    @classmethod
+    def from_torch(cls, torch_ref, mesh_device=None, parallel_config=None, ccl_manager=None):
+        layer = cls(
+            torch_ref=torch_ref, mesh_device=mesh_device, parallel_config=parallel_config, ccl_manager=ccl_manager
+        )
+        return layer
+
+    def load_torch_state_dict(self, state_dict):
+        for i, state in enumerate(indexed_substates(state_dict, "attentions")):
+            self.attentions[i].load_torch_state_dict(state)
+        for i, state in enumerate(indexed_substates(state_dict, "resnets")):
+            self.resnets[i].load_torch_state_dict(state)
+
+    def __call__(self, x):
+        x = self.resnets[0](x)
+        x = self.attentions[0](x)
+        return self.resnets[1](x)
+
+
+# TODO: Clean up, and factor out duplicate code
+class VAEDecoder:
+    def __init__(
+        self,
+        block_out_channels=(128, 256, 512, 512),
+        in_channels=16,
+        out_channels=3,
+        layers_per_block=2,
+        norm_num_groups=32,
+        torch_ref=None,
+        mesh_device=None,
+        parallel_config=None,
+        ccl_manager=None,
+    ):
+        """
+        Initialize the VAEDecoder.
+        Args:
+            block_out_channels: The number of channels for the updecoder blocks. They are also used to support other layers and blocks
+            in_channels: The number of channels in the input image.
+            out_channels: The number of channels in the output image.
+            layers_per_block: The number of Resnet layers (blocks) in each updecoder.
+            norm_num_groups: The number of groups in the normalization layer.
+            torch_ref: The reference to the torch model.
+            mesh_device: The device to use for the model.
+            parallel_config: The parallel config to use for the model.
+            ccl_manager: The ccl manager to use for the model.
+        """
+        # TODO: Add support for torch_ref
+        if torch_ref is None:
+            self.conv_in = Conv2d(
+                in_channels,
+                block_out_channels[-1],
+                kernel_size=(3, 3),
+                padding=(1, 1),
+                mesh_device=mesh_device,
+                out_mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+                ccl_manager=ccl_manager,
+            )
+            self.mid_block = UnetMidBlock2D(
+                in_channels=block_out_channels[-1],
+                attention_head_dim=block_out_channels[-1],
+                resnet_groups=norm_num_groups,
+                mesh_device=mesh_device,
+                parallel_config=parallel_config,
+                ccl_manager=ccl_manager,
+            )
+
+            self.up_blocks = []
+            reversed_block_out_channels = list(reversed(block_out_channels))
+            prev_output_channel = reversed_block_out_channels[0]
+            for i, output_channel in enumerate(reversed_block_out_channels):
+                is_final_block = i == len(reversed_block_out_channels) - 1
+
+                up_block = UpDecoderBlock2D(
+                    num_layers=layers_per_block + 1,
+                    in_channels=prev_output_channel,
+                    out_channels=output_channel,
+                    add_upsample=not is_final_block,
+                    resnet_groups=norm_num_groups,
+                )
+
+                self.up_blocks.append(up_block)
+                prev_output_channel = output_channel
+
+            self.conv_norm_out = GroupNorm(
+                num_groups=norm_num_groups,
+                num_channels=block_out_channels[0],
+                mesh_device=mesh_device,
+                mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            )
+
+            self.conv_out = Conv2d(
+                block_out_channels[0],
+                out_channels,
+                kernel_size=(3, 3),
+                padding=(1, 1),
+                mesh_device=mesh_device,
+                ccl_manager=ccl_manager,
+            )
+
+        else:
+            self.conv_in = Conv2d.from_torch(
+                torch_ref.conv_in,
+                mesh_device=mesh_device,
+                out_mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+                ccl_manager=ccl_manager,
+            )
+            self.mid_block = UnetMidBlock2D.from_torch(
+                torch_ref=torch_ref.mid_block,
+                mesh_device=mesh_device,
+                parallel_config=parallel_config,
+                ccl_manager=ccl_manager,
+            )
+
+            self.up_blocks = [
+                UpDecoderBlock2D.from_torch(
+                    torch_ref=up_block,
+                    mesh_device=mesh_device,
+                    parallel_config=parallel_config,
+                    ccl_manager=ccl_manager,
+                )
+                for up_block in torch_ref.up_blocks
+            ]
+
+            self.conv_norm_out = GroupNorm.from_torch(
+                torch_ref=torch_ref.conv_norm_out,
+                mesh_device=mesh_device,
+                mesh_axis=parallel_config.tensor_parallel.mesh_axis,
+            )
+
+            self.conv_out = Conv2d.from_torch(
+                torch_ref.conv_out,
+                mesh_device=mesh_device,
+                ccl_manager=ccl_manager,
+            )
+
+        self._tp_axis = parallel_config.tensor_parallel.mesh_axis
+        self._ccl_manager = ccl_manager
+
+    @classmethod
+    def from_torch(cls, torch_ref, mesh_device=None, parallel_config=None, ccl_manager=None):
+        vae_model = cls(
+            torch_ref=torch_ref, mesh_device=mesh_device, parallel_config=parallel_config, ccl_manager=ccl_manager
+        )
+        return vae_model
+
+    def load_torch_state_dict(self, state_dict):
+        self.conv_in.load_torch_state_dict(substate(state_dict, "conv_in"))
+        self.mid_block.load_torch_state_dict(substate(state_dict, "mid_block"))
+        for i, state in enumerate(indexed_substates(state_dict, "up_blocks")):
+            self.up_blocks[i].load_torch_state_dict(state)
+        self.conv_norm_out.load_torch_state_dict(substate(state_dict, "conv_norm_out"))
+        self.conv_out.load_torch_state_dict(substate(state_dict, "conv_out"))
+
+    def __call__(self, x):
+        x = self.conv_in(x)
+        x = self.mid_block(x)
+        for up_block in self.up_blocks:
+            x = up_block(x)
+        x = self.conv_norm_out(x)
+        x = ttnn.silu(x)
+        x = vae_all_gather(self._ccl_manager, x, cluster_axis=self._tp_axis)
+        x = self.conv_out(x)
+        return x

--- a/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
+++ b/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
@@ -441,6 +441,8 @@ class StableDiffusion3MediumPipeline:
     ):
         # default config per mesh shape
         default_config = {
+            (1, 1): {"cfg_config": (1, 0), "sp_config": (1, 0), "tp_config": (1, 0), "num_links": 1},  # N150
+            (1, 2): {"cfg_config": (2, 1), "sp_config": (1, 0), "tp_config": (1, 0), "num_links": 1},  # N300
             (2, 4): {"cfg_config": (2, 1), "sp_config": (2, 0), "tp_config": (2, 1), "num_links": 1},
             (4, 8): {"cfg_config": (2, 1), "sp_config": (4, 0), "tp_config": (4, 1), "num_links": 4},
         }
@@ -804,9 +806,10 @@ class StableDiffusion3MediumPipeline:
         if do_classifier_free_guidance:
             if not self.dit_parallel_config.cfg_parallel.factor > 1:
                 # Single device case - direct operations work
-                split_pos = noise_pred_list[0].shape[0] // 2
-                uncond = noise_pred_list[0][0:split_pos]
-                cond = noise_pred_list[0][split_pos:]
+                # With guidance_cond=2, tensor shape is [1, 2, seq_len, ...] where batch dim is shape[1]
+                split_pos = noise_pred_list[0].shape[1] // 2
+                uncond = noise_pred_list[0][:, 0:split_pos, :, :]
+                cond = noise_pred_list[0][:, split_pos:, :, :]
                 noise_pred_list[0] = uncond + guidance_scale * (cond - uncond)
             else:
                 uncond = ttnn.to_torch(ttnn.get_device_tensors(noise_pred_list[0])[0].cpu(blocking=True)).to(

--- a/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
+++ b/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager, nullcontext
 from models.experimental.tt_dit.encoders.clip.model_clip import CLIPEncoder, CLIPConfig
 from models.experimental.tt_dit.encoders.t5.model_t5 import T5Encoder, T5Config
 
-# Import SD3.5 Medium transformer
 from models.experimental.tt_dit.models.transformers.sd35_med.transformer_sd35_medium import SD3Transformer2DModel
 from models.experimental.tt_dit.models.vae.vae_sd35_med import VAEDecoder
 from models.experimental.tt_dit.parallel.manager import CCLManager
@@ -38,6 +37,10 @@ from models.experimental.tt_dit.utils.cache import (
     load_cache_dict,
     cache_dict_exists,
     get_and_create_cache_path,
+)
+from models.experimental.tt_dit.pipelines.stable_diffusion_35_large.pipeline_stable_diffusion_35_large import (
+    _get_clip_prompt_embeds,
+    _get_t5_prompt_embeds,
 )
 
 TILE_SIZE = 32
@@ -123,9 +126,6 @@ class StableDiffusion3MediumPipeline:
         # Create submeshes
         submesh_shape = list(mesh_device.shape)
         submesh_shape[parallel_config.cfg_parallel.mesh_axis] //= parallel_config.cfg_parallel.factor
-        logger.info(f"Parallel config: {parallel_config}")
-        logger.info(f"Original mesh shape: {mesh_device.shape}")
-        logger.info(f"Creating submeshes with shape {submesh_shape}")
         self.submesh_devices = self._mesh_device.create_submeshes(ttnn.MeshShape(*submesh_shape))
 
         self.ccl_managers = [
@@ -154,7 +154,6 @@ class StableDiffusion3MediumPipeline:
             assert (
                 cfg_shape[0] * cfg_shape[1] == encoder_tp_factor
             ), f"Cannot reshape {cfg_shape} to a 1x{encoder_tp_factor} mesh"
-            logger.info(f"Reshaping submesh device 0 from {cfg_shape} to (1, {encoder_tp_factor}) for CLIP")
             self.desired_encoder_submesh_shape = (1, encoder_tp_factor)
 
         else:
@@ -196,7 +195,6 @@ class StableDiffusion3MediumPipeline:
             torch_dtype=torch.bfloat16,
         )
         torch_transformer.eval()
-        logger.debug("Loaded torch transformer")
 
         assert isinstance(self._tokenizer_1, CLIPTokenizer)
         assert isinstance(self._tokenizer_2, CLIPTokenizer)
@@ -237,8 +235,6 @@ class StableDiffusion3MediumPipeline:
         # Set patch_size
         self.patch_size = patch_size
 
-        logger.info(f"Using transformer depth={transformer_depth}")
-
         self.transformers = []
         for i, submesh_device in enumerate(self.submesh_devices):
             tt_transformer = SD3Transformer2DModel(
@@ -266,16 +262,11 @@ class StableDiffusion3MediumPipeline:
                 )
                 # create cache if it doesn't exist
                 if not cache_dict_exists(cache_path):
-                    logger.info(
-                        f"Cache does not exist. Creating cache: {cache_path} and loading transformer weights from PyTorch state dict"
-                    )
                     tt_transformer.load_torch_state_dict(torch_transformer.state_dict())
                     save_cache_dict(tt_transformer.to_cached_state_dict(cache_path), cache_path)
                 else:
-                    logger.info(f"Loading transformer weights from cache: {cache_path}")
                     tt_transformer.from_cached_state_dict(load_cache_dict(cache_path))
             else:
-                logger.info("Loading transformer weights from PyTorch state dict")
                 tt_transformer.load_torch_state_dict(torch_transformer.state_dict())
 
             self.transformers.append(tt_transformer)
@@ -466,11 +457,6 @@ class StableDiffusion3MediumPipeline:
         submesh_shape[cfg_axis] //= cfg_factor
         enable_t5_text_encoder = submesh_shape[1] == 4  # T5 only works if submesh doesn't need reshaping
 
-        logger.info(f"Mesh device shape: {mesh_device.shape}")
-        logger.info(f"Submesh shape: {submesh_shape}")
-        logger.info(f"Parallel config: {parallel_config}")
-        logger.info(f"T5 enabled: {enable_t5_text_encoder}")
-
         # Create pipeline
         pipeline = StableDiffusion3MediumPipeline(
             mesh_device=mesh_device,
@@ -564,10 +550,6 @@ class StableDiffusion3MediumPipeline:
                 self._num_channels_latents,
             )
 
-            logger.debug(f"Latents shape: {latents_shape}")
-
-            logger.info("encoding prompts...")
-
             with timer.time_section("total_encoding") if timer else nullcontext():
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
                     self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
@@ -587,12 +569,9 @@ class StableDiffusion3MediumPipeline:
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
                     self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
                 prompt_encoding_end_time = time.time()
-                logger.info("preparing timesteps...")
 
             self._scheduler.set_timesteps(num_inference_steps)
             timesteps = self._scheduler.timesteps
-
-            logger.info("preparing latents...")
 
             if seed is not None:
                 torch.manual_seed(seed)
@@ -742,26 +721,17 @@ class StableDiffusion3MediumPipeline:
                 image_decoding_start_time = time.time()
                 decoded_output = self._vae_decode(tt_latents_step_list[self.vae_submesh_idx], width, height)
                 decoded_output = ttnn.to_torch(ttnn.get_device_tensors(decoded_output)[0]).permute(0, 3, 1, 2)
-                logger.debug(
-                    f"VAE decoded output: min={decoded_output.min():.4f}, max={decoded_output.max():.4f}, mean={decoded_output.mean():.4f}"
-                )
 
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
                     # If reshaping, vae device is same as encoder device
                     self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
                 image = self._image_processor.postprocess(decoded_output, output_type="pt")
-                logger.debug(f"Postprocessed image shape: {image.shape}")
                 assert isinstance(image, torch.Tensor)
                 image_decoding_end_time = time.time()
 
                 output = self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(image))
 
                 end_time = time.time()
-
-                logger.info(f"prompt encoding duration: {prompt_encoding_end_time - prompt_encoding_start_time}")
-                logger.info(f"denoising duration: {denoising_end_time - denoising_start_time}")
-                logger.info(f"image decoding duration: {image_decoding_end_time - image_decoding_start_time}")
-                logger.info(f"total runtime: {end_time - start_time}")
 
         return output
 
@@ -887,10 +857,6 @@ class StableDiffusion3MediumPipeline:
         clip_skip: int | None,
     ):
         """Encode prompts using CLIP and T5 text encoders"""
-        from ...pipelines.stable_diffusion_35_large.pipeline_stable_diffusion_35_large import (
-            _get_clip_prompt_embeds,
-            _get_t5_prompt_embeds,
-        )
 
         timer = self.timing_collector
 
@@ -1013,21 +979,12 @@ class StableDiffusion3MediumPipeline:
         while torch_latents.dim() > 4:
             torch_latents = torch_latents.squeeze(0)
 
-        # Apply VAE scaling (in NHWC format)
-        logger.debug(
-            f"Latents before VAE scaling: min={torch_latents.min():.4f}, max={torch_latents.max():.4f}, mean={torch_latents.mean():.4f}"
-        )
-
         # Re-center latents to compensate for accumulated numerical drift
         latent_mean = torch_latents.mean()
         if abs(latent_mean) > 0.05:
-            logger.debug(f"Correcting latent mean drift: {latent_mean:.4f}")
             torch_latents = torch_latents - latent_mean
 
         torch_latents = (torch_latents / self._torch_vae_scaling_factor) + self._torch_vae_shift_factor
-        logger.debug(
-            f"Latents after VAE scaling: min={torch_latents.min():.4f}, max={torch_latents.max():.4f}, mean={torch_latents.mean():.4f}"
-        )
 
         if self.desired_encoder_submesh_shape != self.original_submesh_shape:
             # If reshaping, vae device is same as encoder device
@@ -1171,10 +1128,6 @@ def _get_t5_prompt_embeds(
 
     if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
         removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer_max_length - 1 : -1])
-        logger.warning(
-            "The following part of your input was truncated because `max_sequence_length` is set to "
-            f" {max_sequence_length} tokens: {removed_text}"
-        )
 
     tt_text_input_ids = ttnn.from_torch(
         text_input_ids,

--- a/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
+++ b/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
@@ -1,0 +1,1210 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List
+from PIL import Image
+
+import torch
+import tqdm
+import ttnn
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+from diffusers.models.transformers.transformer_sd3 import SD3Transformer2DModel as TorchSD3Transformer2DModel
+from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
+from loguru import logger
+from transformers import CLIPTextModelWithProjection, CLIPTokenizer, T5EncoderModel, T5TokenizerFast
+from contextlib import contextmanager, nullcontext
+
+from ...encoders.clip.model_clip import CLIPEncoder, CLIPConfig
+from ...encoders.t5.model_t5 import T5Encoder, T5Config
+
+# Import SD3.5 Medium transformer
+from ...models.transformers.sd35_med.transformer_sd35_medium import SD3Transformer2DModel
+from ...models.vae.vae_sd35 import VAEDecoder
+from ...parallel.manager import CCLManager
+from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, VAEParallelConfig, ParallelFactor
+from ...utils.padding import PaddingConfig
+from ...utils.cache import save_cache_dict, load_cache_dict, cache_dict_exists, get_and_create_cache_path
+
+TILE_SIZE = 32
+
+
+@dataclass
+class TimingData:
+    clip_encoding_time: float = 0.0
+    t5_encoding_time: float = 0.0
+    total_encoding_time: float = 0.0
+    denoising_step_times: List[float] = field(default_factory=list)
+    vae_decoding_time: float = 0.0
+    total_time: float = 0.0
+
+
+class TimingCollector:
+    def __init__(self):
+        self.timings: Dict[str, float] = {}
+        self.step_timings: Dict[str, List[float]] = {}
+
+    @contextmanager
+    def time_section(self, name: str):
+        start = time.time()
+        yield
+        end = time.time()
+        self.timings[name] = end - start
+
+    @contextmanager
+    def time_step(self, name: str):
+        start = time.time()
+        yield
+        end = time.time()
+        if name not in self.step_timings:
+            self.step_timings[name] = []
+        self.step_timings[name].append(end - start)
+
+    def get_timing_data(self) -> TimingData:
+        return TimingData(
+            clip_encoding_time=self.timings.get("clip_encoding", 0.0),
+            t5_encoding_time=self.timings.get("t5_encoding", 0.0),
+            total_encoding_time=self.timings.get("total_encoding", 0.0),
+            denoising_step_times=self.step_timings.get("denoising_step", []),
+            vae_decoding_time=self.timings.get("vae_decoding", 0.0),
+            total_time=self.timings.get("total", 0.0),
+        )
+
+    def reset(self):
+        self.timings = {}
+        self.step_timings = {}
+        return self
+
+
+@dataclass
+class PipelineTrace:
+    spatial_input: ttnn.Tensor
+    prompt_input: ttnn.Tensor
+    pooled_projection_input: ttnn.Tensor
+    timestep_input: ttnn.Tensor
+    latents_output: ttnn.Tensor
+    tid: int
+
+
+class StableDiffusion3MediumPipeline:
+    def __init__(
+        self,
+        *,
+        mesh_device: ttnn.MeshDevice,
+        enable_t5_text_encoder: bool = True,
+        guidance_cond: int,
+        parallel_config: DiTParallelConfig,
+        num_links: int,
+        height: int,
+        width: int,
+        model_checkpoint_path: str,
+        use_cache=False,
+    ) -> None:
+        self._mesh_device = mesh_device
+        self._init_height = height
+        self._init_width = width
+
+        self.dit_parallel_config = parallel_config
+
+        # Create submeshes
+        submesh_shape = list(mesh_device.shape)
+        submesh_shape[parallel_config.cfg_parallel.mesh_axis] //= parallel_config.cfg_parallel.factor
+        logger.info(f"Parallel config: {parallel_config}")
+        logger.info(f"Original mesh shape: {mesh_device.shape}")
+        logger.info(f"Creating submeshes with shape {submesh_shape}")
+        self.submesh_devices = self._mesh_device.create_submeshes(ttnn.MeshShape(*submesh_shape))
+
+        self.ccl_managers = [
+            CCLManager(submesh_device, num_links=num_links, topology=ttnn.Topology.Linear)
+            for submesh_device in self.submesh_devices
+        ]
+        # Hacky submesh reshapes and assignment to parallelize encoders and VAE
+        encoder_device = self.submesh_devices[0]
+        self.original_submesh_shape = tuple(encoder_device.shape)
+        self.desired_encoder_submesh_shape = tuple(encoder_device.shape)
+
+        # Determine the number of devices available for parallelization
+        num_devices = encoder_device.shape[0] * encoder_device.shape[1]
+
+        # Use factor=1 for minimal test configurations, factor=4 for production
+        encoder_tp_factor = 4 if num_devices >= 4 else 1
+        vae_tp_factor = 4 if num_devices >= 4 else 1
+
+        if encoder_device.shape[1] != encoder_tp_factor and num_devices >= encoder_tp_factor:
+            # If reshaping, vae_device must be on submesh 0. That means T5 can't fit, so disable it.
+            vae_submesh_idx = 0
+            if enable_t5_text_encoder:
+                logger.warning(
+                    "If VAE submesh must be reshaped, VAE must be on submesh 0, and T5 cannot fit. Disabling T5."
+                )
+                enable_t5_text_encoder = False
+
+            cfg_shape = tuple(encoder_device.shape)
+            assert (
+                cfg_shape[0] * cfg_shape[1] == encoder_tp_factor
+            ), f"Cannot reshape {cfg_shape} to a 1x{encoder_tp_factor} mesh"
+            logger.info(f"Reshaping submesh device 0 from {cfg_shape} to (1, {encoder_tp_factor}) for CLIP")
+            self.desired_encoder_submesh_shape = (1, encoder_tp_factor)
+
+        else:
+            # vae_device can only be on submesh 1 if submesh is not getting reshaped.
+            vae_submesh_idx = 1 if len(self.submesh_devices) > 1 else 0
+        vae_device = self.submesh_devices[vae_submesh_idx]
+
+        # Create encoder parallel config
+        encoder_parallel_config = EncoderParallelConfig(
+            tensor_parallel=ParallelFactor(factor=encoder_tp_factor, mesh_axis=1)
+        )
+
+        self.encoder_parallel_config = encoder_parallel_config
+        self.encoder_device = encoder_device
+
+        vae_parallel_config = VAEParallelConfig(tensor_parallel=ParallelFactor(factor=vae_tp_factor, mesh_axis=1))
+        self.vae_parallel_config = vae_parallel_config
+        self.vae_device = vae_device
+        self.vae_submesh_idx = vae_submesh_idx
+
+        logger.info("loading models...")
+        self._tokenizer_1 = CLIPTokenizer.from_pretrained(model_checkpoint_path, subfolder="tokenizer")
+        self._tokenizer_2 = CLIPTokenizer.from_pretrained(model_checkpoint_path, subfolder="tokenizer_2")
+        self._tokenizer_3 = T5TokenizerFast.from_pretrained(model_checkpoint_path, subfolder="tokenizer_3")
+        self._text_encoder_1 = CLIPTextModelWithProjection.from_pretrained(
+            model_checkpoint_path, subfolder="text_encoder"
+        )
+        self._text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(
+            model_checkpoint_path, subfolder="text_encoder_2"
+        )
+        if enable_t5_text_encoder:
+            torch_text_encoder_3 = T5EncoderModel.from_pretrained(model_checkpoint_path, subfolder="text_encoder_3")
+        self._scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(model_checkpoint_path, subfolder="scheduler")
+        self._torch_vae = AutoencoderKL.from_pretrained(model_checkpoint_path, subfolder="vae")
+
+        # Load SD3.5 Medium transformer
+        torch_transformer = TorchSD3Transformer2DModel.from_pretrained(
+            model_checkpoint_path,
+            subfolder="transformer",
+            torch_dtype=torch.bfloat16,  # bfloat16 is the native datatype of the model
+        )
+        torch_transformer.eval()
+        print("torch_transformer: ", torch_transformer)
+
+        assert isinstance(self._tokenizer_1, CLIPTokenizer)
+        assert isinstance(self._tokenizer_2, CLIPTokenizer)
+        assert isinstance(self._tokenizer_3, T5TokenizerFast)
+        assert isinstance(self._text_encoder_1, CLIPTextModelWithProjection)
+        assert isinstance(self._text_encoder_2, CLIPTextModelWithProjection)
+        assert isinstance(self._scheduler, FlowMatchEulerDiscreteScheduler)
+        assert isinstance(self._torch_vae, AutoencoderKL)
+        assert isinstance(torch_transformer, TorchSD3Transformer2DModel)
+
+        logger.info("creating TT-NN SD3.5 Medium transformer...")
+
+        assert "stabilityai/stable-diffusion-3.5-medium" in str(model_checkpoint_path)
+
+        if torch_transformer.config.num_attention_heads % parallel_config.tensor_parallel.factor != 0:
+            padding_config = PaddingConfig.from_tensor_parallel_factor(
+                torch_transformer.config.num_attention_heads,
+                torch_transformer.config.attention_head_dim,
+                parallel_config.tensor_parallel.factor,
+            )
+        else:
+            padding_config = None
+
+        # Get model configuration from torch transformer config
+        transformer_config = torch_transformer.config
+        sample_size = getattr(transformer_config, "sample_size", 128)
+        patch_size = getattr(transformer_config, "patch_size", 2)
+        attention_head_dim = transformer_config.attention_head_dim
+        num_attention_heads = transformer_config.num_attention_heads
+        in_channels = transformer_config.in_channels
+        joint_attention_dim = transformer_config.joint_attention_dim
+        caption_projection_dim = getattr(transformer_config, "caption_projection_dim", 2432)
+        pooled_projection_dim = getattr(transformer_config, "pooled_projection_dim", 2048)
+        out_channels = getattr(transformer_config, "out_channels", 16)
+        pos_embed_max_size = getattr(transformer_config, "pos_embed_max_size", 192)
+        transformer_depth = getattr(transformer_config, "num_layers", 24)
+
+        # Set patch_size early since it's used in transformer creation
+        self.patch_size = patch_size
+
+        logger.info(f"Using transformer depth={transformer_depth}")
+
+        self.transformers = []
+        for i, submesh_device in enumerate(self.submesh_devices):
+            # Use the new SD3Transformer2DModel implementation
+            tt_transformer = SD3Transformer2DModel(
+                sample_size=sample_size,
+                patch_size=patch_size,
+                in_channels=in_channels,
+                num_layers=transformer_depth,
+                attention_head_dim=attention_head_dim,
+                num_attention_heads=num_attention_heads,
+                joint_attention_dim=joint_attention_dim,
+                caption_projection_dim=caption_projection_dim,
+                pooled_projection_dim=pooled_projection_dim,
+                out_channels=out_channels,
+                pos_embed_max_size=pos_embed_max_size,
+                mesh_device=submesh_device,
+            )
+
+            if use_cache:
+                cache_path = get_and_create_cache_path(
+                    model_name="stable-diffusion-3.5-medium",
+                    subfolder="transformer",
+                    parallel_config=self.dit_parallel_config,
+                    mesh_shape=tuple(submesh_device.shape),
+                    dtype="bf16",
+                )
+                # create cache if it doesn't exist
+                if not cache_dict_exists(cache_path):
+                    logger.info(
+                        f"Cache does not exist. Creating cache: {cache_path} and loading transformer weights from PyTorch state dict"
+                    )
+                    tt_transformer.load_torch_state_dict(torch_transformer.state_dict())
+                    save_cache_dict(tt_transformer.to_cached_state_dict(cache_path), cache_path)
+                else:
+                    logger.info(f"Loading transformer weights from cache: {cache_path}")
+                    tt_transformer.from_cached_state_dict(load_cache_dict(cache_path))
+            else:
+                logger.info("Loading transformer weights from PyTorch state dict")
+                tt_transformer.load_torch_state_dict(torch_transformer.state_dict())
+
+            self.transformers.append(tt_transformer)
+            ttnn.synchronize_device(submesh_device)
+
+        self._num_channels_latents = torch_transformer.config.in_channels
+        self._joint_attention_dim = torch_transformer.config.joint_attention_dim
+
+        self._block_out_channels = self._torch_vae.config.block_out_channels
+        self._torch_vae_scaling_factor = self._torch_vae.config.scaling_factor
+        self._torch_vae_shift_factor = self._torch_vae.config.shift_factor
+
+        self._torch_vae_scale_factor = 2 ** (len(self._block_out_channels) - 1)
+        self._image_processor = VaeImageProcessor(vae_scale_factor=self._torch_vae_scale_factor)
+
+        if self.desired_encoder_submesh_shape != self.original_submesh_shape:
+            # HACK: reshape submesh device 0 to 1D
+            self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
+
+        logger.info("creating TT-NN CLIP text encoder...")
+
+        # Create CLIP config for encoder 1
+        clip_config_1 = CLIPConfig(
+            vocab_size=self._text_encoder_1.config.vocab_size,
+            embed_dim=self._text_encoder_1.config.hidden_size,
+            ff_dim=self._text_encoder_1.config.intermediate_size,
+            num_heads=self._text_encoder_1.config.num_attention_heads,
+            num_hidden_layers=self._text_encoder_1.config.num_hidden_layers,
+            max_prompt_length=77,
+            layer_norm_eps=self._text_encoder_1.config.layer_norm_eps,
+            attention_dropout=self._text_encoder_1.config.attention_dropout,
+            hidden_act=self._text_encoder_1.config.hidden_act,
+        )
+
+        # Create CLIP config for encoder 2
+        clip_config_2 = CLIPConfig(
+            vocab_size=self._text_encoder_2.config.vocab_size,
+            embed_dim=self._text_encoder_2.config.hidden_size,
+            ff_dim=self._text_encoder_2.config.intermediate_size,
+            num_heads=self._text_encoder_2.config.num_attention_heads,
+            num_hidden_layers=self._text_encoder_2.config.num_hidden_layers,
+            max_prompt_length=77,
+            layer_norm_eps=self._text_encoder_2.config.layer_norm_eps,
+            attention_dropout=self._text_encoder_2.config.attention_dropout,
+            hidden_act=self._text_encoder_2.config.hidden_act,
+        )
+
+        # Store original state dicts before creating new encoders
+        text_encoder_1_state_dict = self._text_encoder_1.state_dict()
+        text_encoder_2_state_dict = self._text_encoder_2.state_dict()
+
+        # Create new CLIP encoders
+        self._text_encoder_1 = CLIPEncoder(
+            config=clip_config_1,
+            mesh_device=encoder_device,
+            ccl_manager=self.ccl_managers[0],  # use CCL manager for submesh 0
+            parallel_config=encoder_parallel_config,
+            eos_token_id=2,  # default EOS token ID for CLIP
+        )
+
+        self._text_encoder_2 = CLIPEncoder(
+            config=clip_config_2,
+            mesh_device=encoder_device,
+            ccl_manager=self.ccl_managers[0],  # Use CCL manager for submesh 0
+            parallel_config=encoder_parallel_config,
+            eos_token_id=2,  # default EOS token ID for CLIP
+        )
+
+        # Load state dicts into new encoders
+        self._text_encoder_1.load_torch_state_dict(text_encoder_1_state_dict)
+        self._text_encoder_2.load_torch_state_dict(text_encoder_2_state_dict)
+
+        if enable_t5_text_encoder:
+            logger.info("creating TT-NN T5 text encoder...")
+
+            # Create T5 config
+            t5_config = T5Config(
+                vocab_size=torch_text_encoder_3.config.vocab_size,
+                embed_dim=torch_text_encoder_3.config.d_model,
+                ff_dim=torch_text_encoder_3.config.d_ff,
+                kv_dim=torch_text_encoder_3.config.d_kv,
+                num_heads=torch_text_encoder_3.config.num_heads,
+                num_hidden_layers=torch_text_encoder_3.config.num_layers,
+                max_prompt_length=256,  # default T5 max prompt length
+                layer_norm_eps=torch_text_encoder_3.config.layer_norm_epsilon,
+                relative_attention_num_buckets=torch_text_encoder_3.config.relative_attention_num_buckets,
+                relative_attention_max_distance=torch_text_encoder_3.config.relative_attention_max_distance,
+            )
+
+            # Store original state dict before creating new encoder
+            torch_text_encoder_3_state_dict = torch_text_encoder_3.state_dict()
+
+            # Create new T5 encoder
+            self._text_encoder_3 = T5Encoder(
+                config=t5_config,
+                mesh_device=encoder_device,
+                ccl_manager=self.ccl_managers[0],  # use CCL manager for submesh 0
+                parallel_config=encoder_parallel_config,
+            )
+
+            # Load state dict into new encoder
+            self._text_encoder_3.load_torch_state_dict(torch_text_encoder_3_state_dict)
+        else:
+            self._text_encoder_3 = None
+
+        self.timing_collector = None  # Set externally when timing is needed
+
+        self._trace = None
+
+        # intermediate buffers for safe tracing
+        self._intermediate_noise_list = []
+        self._sigma_difference_list = []
+        self._vae_input_latents = None
+
+        ttnn.synchronize_device(self.encoder_device)
+
+        self._vae_decoder = VAEDecoder.from_torch(
+            torch_ref=self._torch_vae.decoder,
+            mesh_device=self.vae_device,
+            parallel_config=self.vae_parallel_config,
+            ccl_manager=self.ccl_managers[vae_submesh_idx],
+        )
+
+        if self.desired_encoder_submesh_shape != self.original_submesh_shape:
+            # HACK: reshape submesh device 0 to 1D
+            # If reshaping, vae device is same as encoder device
+            self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
+
+    def prepare(
+        self,
+        *,
+        batch_size: int,
+        num_images_per_prompt: int = 1,
+        width: int = 1024,
+        height: int = 1024,
+        guidance_scale: float = 4.5,
+        max_t5_sequence_length: int = 256,
+        prompt_sequence_length: int = 333,
+        spatial_sequence_length: int = 4096,
+    ) -> None:
+        self._prepared_batch_size = batch_size
+        self._prepared_num_images_per_prompt = num_images_per_prompt
+        self._prepared_width = width
+        self._prepared_height = height
+        self._prepared_guidance_scale = guidance_scale
+        self._prepared_max_t5_sequence_length = max_t5_sequence_length
+        self._prepared_prompt_sequence_length = prompt_sequence_length
+
+    @staticmethod
+    def create_pipeline(
+        mesh_device,
+        batch_size=1,
+        image_w=1024,
+        image_h=1024,
+        guidance_scale=3.5,
+        num_images_per_prompt=1,
+        max_t5_sequence_length=256,
+        prompt_sequence_length=333,
+        spatial_sequence_length=4096,
+        cfg_config=None,
+        sp_config=None,
+        tp_config=None,
+        num_links=None,
+        model_checkpoint_path=f"stabilityai/stable-diffusion-3.5-medium",
+        use_cache=False,
+    ):
+        # default config per mesh shape
+        default_config = {
+            (2, 4): {"cfg_config": (2, 1), "sp_config": (2, 0), "tp_config": (2, 1), "num_links": 1},
+            (4, 8): {"cfg_config": (2, 1), "sp_config": (4, 0), "tp_config": (4, 1), "num_links": 4},
+        }
+
+        # get config from user or default if not provided
+        cfg_factor, cfg_axis = cfg_config or default_config[tuple(mesh_device.shape)]["cfg_config"]
+        sp_factor, sp_axis = sp_config or default_config[tuple(mesh_device.shape)]["sp_config"]
+        tp_factor, tp_axis = tp_config or default_config[tuple(mesh_device.shape)]["tp_config"]
+        num_links = num_links or default_config[tuple(mesh_device.shape)]["num_links"]
+
+        parallel_config = DiTParallelConfig(
+            cfg_parallel=ParallelFactor(factor=cfg_factor, mesh_axis=cfg_axis),
+            tensor_parallel=ParallelFactor(factor=tp_factor, mesh_axis=tp_axis),
+            sequence_parallel=ParallelFactor(factor=sp_factor, mesh_axis=sp_axis),
+        )
+
+        guidance_cond = 2 if (guidance_scale > 1 and cfg_factor == 1) else 1
+
+        # Enable T5 based on device configuration
+        # T5 is disabled if mesh needs reshaping for CLIP encoder
+        submesh_shape = list(mesh_device.shape)
+        submesh_shape[cfg_axis] //= cfg_factor
+        enable_t5_text_encoder = submesh_shape[1] == 4  # T5 only works if submesh doesn't need reshaping
+
+        logger.info(f"Mesh device shape: {mesh_device.shape}")
+        logger.info(f"Submesh shape: {submesh_shape}")
+        logger.info(f"Parallel config: {parallel_config}")
+        logger.info(f"T5 enabled: {enable_t5_text_encoder}")
+
+        # Create pipeline
+        pipeline = StableDiffusion3MediumPipeline(
+            mesh_device=mesh_device,
+            enable_t5_text_encoder=enable_t5_text_encoder,
+            guidance_cond=guidance_cond,
+            parallel_config=parallel_config,
+            num_links=num_links,
+            height=image_h,
+            width=image_w,
+            model_checkpoint_path=model_checkpoint_path,
+            use_cache=use_cache,
+        )
+
+        pipeline.prepare(
+            batch_size=batch_size,
+            num_images_per_prompt=num_images_per_prompt,
+            width=image_w,
+            height=image_h,
+            guidance_scale=guidance_scale,
+            max_t5_sequence_length=max_t5_sequence_length,
+            prompt_sequence_length=prompt_sequence_length,
+            spatial_sequence_length=spatial_sequence_length,
+        )
+
+        return pipeline
+
+    def run_single_prompt(self, prompt, negative_prompt="", num_inference_steps=40, seed=None):
+        return self.__call__(
+            prompt_1=[prompt],
+            prompt_2=[prompt],
+            prompt_3=[prompt],
+            negative_prompt_1=[negative_prompt or ""],
+            negative_prompt_2=[negative_prompt or ""],
+            negative_prompt_3=[negative_prompt or ""],
+            num_inference_steps=num_inference_steps,
+            seed=seed,
+            traced=True,
+        )
+
+    def __call__(
+        self,
+        *,
+        prompt_1: list[str],
+        prompt_2: list[str],
+        prompt_3: list[str],
+        negative_prompt_1: list[str],
+        negative_prompt_2: list[str],
+        negative_prompt_3: list[str],
+        num_inference_steps: int = 40,
+        seed: int | None = None,
+        traced: bool = False,
+        clip_skip: int | None = None,
+    ) -> List[Image.Image]:
+        timer = self.timing_collector.reset() if self.timing_collector else None
+
+        with timer.time_section("total") if timer else nullcontext():
+            start_time = time.time()
+
+            # Auto-call prepare() with defaults if not already called
+            if not hasattr(self, "_prepared_batch_size"):
+                batch_size = len(prompt_1)
+                self.prepare(
+                    batch_size=batch_size,
+                    num_images_per_prompt=1,
+                    width=self._init_width,
+                    height=self._init_height,
+                    guidance_scale=4.5,
+                    max_t5_sequence_length=256,
+                    prompt_sequence_length=333,
+                    spatial_sequence_length=4096,
+                )
+
+            batch_size = self._prepared_batch_size
+            num_images_per_prompt = self._prepared_num_images_per_prompt
+            width = self._prepared_width
+            height = self._prepared_height
+            guidance_scale = self._prepared_guidance_scale
+            max_t5_sequence_length = self._prepared_max_t5_sequence_length
+
+            assert height % (self._torch_vae_scale_factor * self.patch_size) == 0
+            assert width % (self._torch_vae_scale_factor * self.patch_size) == 0
+            assert max_t5_sequence_length <= 512  # noqa: PLR2004
+            assert batch_size == len(prompt_1)
+
+            do_classifier_free_guidance = guidance_scale > 1
+            # TODO: pass the patch_size value
+            patch_size = 2
+            latents_shape = (
+                batch_size * num_images_per_prompt,
+                height // self._torch_vae_scale_factor,
+                width // self._torch_vae_scale_factor,
+                self._num_channels_latents,
+            )
+
+            print(f"Latents shape: {latents_shape}")
+
+            logger.info("encoding prompts...")
+
+            with timer.time_section("total_encoding") if timer else nullcontext():
+                if self.desired_encoder_submesh_shape != self.original_submesh_shape:
+                    # HACK: reshape submesh device 0 from 2D to 1D
+                    self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
+                prompt_encoding_start_time = time.time()
+                prompt_embeds, pooled_prompt_embeds = self._encode_prompts(
+                    prompt_1=prompt_1,
+                    prompt_2=prompt_2,
+                    prompt_3=prompt_3,
+                    negative_prompt_1=negative_prompt_1,
+                    negative_prompt_2=negative_prompt_2,
+                    negative_prompt_3=negative_prompt_3,
+                    num_images_per_prompt=num_images_per_prompt,
+                    max_t5_sequence_length=max_t5_sequence_length,
+                    do_classifier_free_guidance=do_classifier_free_guidance,
+                    clip_skip=clip_skip,
+                )
+                if self.desired_encoder_submesh_shape != self.original_submesh_shape:
+                    # HACK: reshape submesh device 0 from 1D to 2D
+                    self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
+                prompt_encoding_end_time = time.time()
+                logger.info("preparing timesteps...")
+
+            self._scheduler.set_timesteps(num_inference_steps)
+            timesteps = self._scheduler.timesteps
+
+            logger.info("preparing latents...")
+
+            if seed is not None:
+                torch.manual_seed(seed)
+            # Latents shape is (batch_size * num_images_per_prompt, H, W, C) in NHWC format
+            # TTNN SD3Transformer2DModel expects NHWC format (same as latents_shape)
+            latents = torch.randn(latents_shape, dtype=prompt_embeds.dtype)
+
+            tt_prompt_embeds_list = []
+            tt_pooled_prompt_embeds_list = []
+            tt_latents_step_list = []
+            for i, submesh_device in enumerate(self.submesh_devices):
+                tt_prompt_embeds = ttnn.from_torch(
+                    prompt_embeds[i].unsqueeze(0).unsqueeze(0)
+                    if self.dit_parallel_config.cfg_parallel.factor == 2
+                    else prompt_embeds,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=submesh_device if not traced else None,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        submesh_device,
+                        tuple(submesh_device.shape),
+                        dims=[None, None],
+                    ),
+                )
+
+                tt_pooled_prompt_embeds = ttnn.from_torch(
+                    pooled_prompt_embeds[i].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+                    if self.dit_parallel_config.cfg_parallel.factor == 2
+                    else pooled_prompt_embeds,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=submesh_device if not traced else None,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        submesh_device,
+                        tuple(submesh_device.shape),
+                        dims=[None, None],
+                    ),
+                )
+
+                shard_latents_dims = [None, None]
+                shard_latents_dims[self.dit_parallel_config.sequence_parallel.mesh_axis] = 2
+                tt_initial_latents = ttnn.from_torch(
+                    latents,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=submesh_device if not traced else None,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        submesh_device,
+                        tuple(submesh_device.shape),
+                        dims=shard_latents_dims,
+                    ),
+                )
+
+                if len(self._intermediate_noise_list) <= i:
+                    self._intermediate_noise_list.append(
+                        ttnn.from_torch(
+                            latents,
+                            layout=ttnn.TILE_LAYOUT,
+                            dtype=ttnn.bfloat16,
+                            device=submesh_device,
+                            mesh_mapper=ttnn.ShardTensor2dMesh(
+                                submesh_device,
+                                tuple(submesh_device.shape),
+                                dims=shard_latents_dims,
+                            ),
+                        )
+                    )
+                    self._sigma_difference_list.append(ttnn.clone(self._intermediate_noise_list[-1]))
+                if traced:
+                    if self._trace is None:
+                        # Push inputs to device
+                        tt_initial_latents = tt_initial_latents.to(submesh_device)
+                        tt_prompt_embeds = tt_prompt_embeds.to(submesh_device)
+                        tt_pooled_prompt_embeds = tt_pooled_prompt_embeds.to(submesh_device)
+                    else:
+                        # Copy inputs to trace
+                        ttnn.copy_host_to_device_tensor(tt_initial_latents, self._trace[i].spatial_input)
+                        ttnn.copy_host_to_device_tensor(tt_prompt_embeds, self._trace[i].prompt_input)
+                        ttnn.copy_host_to_device_tensor(tt_pooled_prompt_embeds, self._trace[i].pooled_projection_input)
+                        # Ensure trace inputs are passed to function
+                        tt_initial_latents = self._trace[i].spatial_input
+                        tt_prompt_embeds = self._trace[i].prompt_input
+                        tt_pooled_prompt_embeds = self._trace[i].pooled_projection_input
+
+                tt_prompt_embeds_list.append(tt_prompt_embeds)
+                tt_pooled_prompt_embeds_list.append(tt_pooled_prompt_embeds)
+                tt_latents_step_list.append(tt_initial_latents)
+
+            logger.info("denoising...")
+            denoising_start_time = time.time()
+
+            for i, t in enumerate(tqdm.tqdm(timesteps)):
+                with timer.time_step("denoising_step") if timer else nullcontext():
+                    sigma_difference = self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]
+
+                    tt_timestep_list = []
+                    tt_sigma_difference_list = []
+                    for submesh_device in self.submesh_devices:
+                        tt_timestep = ttnn.full(
+                            [1, 1, 1, 1],
+                            fill_value=t,
+                            layout=ttnn.TILE_LAYOUT,
+                            dtype=ttnn.float32,
+                            device=submesh_device,  # Always create on device
+                        )
+                        tt_timestep_list.append(tt_timestep)
+
+                        tt_sigma_difference_list.append(
+                            ttnn.full(
+                                tt_latents_step_list[0].shape,
+                                fill_value=sigma_difference,
+                                layout=ttnn.TILE_LAYOUT,
+                                dtype=ttnn.bfloat16,
+                                device=submesh_device,  # Create on device
+                            )
+                        )
+
+                    # Calculate spatial sequence length based on actual image dimensions
+                    latent_h = height // self._torch_vae_scale_factor
+                    latent_w = width // self._torch_vae_scale_factor
+                    actual_spatial_seq_len = (latent_h // self.patch_size) * (latent_w // self.patch_size)
+
+                    # Calculate prompt sequence length based on whether T5 is enabled
+                    # CLIP: 77 tokens, T5: max_t5_sequence_length tokens (or 77 zeros if disabled)
+                    clip_seq_len = 77
+                    if self._text_encoder_3 is not None:
+                        actual_prompt_seq_len = clip_seq_len + max_t5_sequence_length
+                    else:
+                        actual_prompt_seq_len = clip_seq_len + clip_seq_len  # 77 + 77 = 154
+
+                    tt_latents_step_list = self._step(
+                        timestep=tt_timestep_list,
+                        latents=tt_latents_step_list,  # tt_latents,
+                        do_classifier_free_guidance=do_classifier_free_guidance,
+                        prompt_embeds=tt_prompt_embeds_list,
+                        pooled_prompt_embeds=tt_pooled_prompt_embeds_list,
+                        guidance_scale=guidance_scale,
+                        sigma_difference=tt_sigma_difference_list,
+                        prompt_sequence_length=actual_prompt_seq_len,
+                        spatial_sequence_length=actual_spatial_seq_len,
+                        traced=traced,
+                    )
+
+            denoising_end_time = time.time()
+
+            logger.info("decoding image...")
+
+            with timer.time_section("vae_decoding") if timer else nullcontext():
+                image_decoding_start_time = time.time()
+                decoded_output = self._vae_decode(tt_latents_step_list[self.vae_submesh_idx], width, height)
+                decoded_output = ttnn.to_torch(ttnn.get_device_tensors(decoded_output)[0]).permute(0, 3, 1, 2)
+                logger.debug(
+                    f"VAE decoded output: min={decoded_output.min():.4f}, max={decoded_output.max():.4f}, mean={decoded_output.mean():.4f}"
+                )
+
+                # HACK: reshape submesh device 0 from 1D to 2D
+                if self.desired_encoder_submesh_shape != self.original_submesh_shape:
+                    # If reshaping, vae device is same as encoder device
+                    self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
+                # image = self._torch_vae.decoder(tt_latents)
+                image = self._image_processor.postprocess(decoded_output, output_type="pt")
+                print(f"postprocessed image shape: {image.shape}")
+                assert isinstance(image, torch.Tensor)
+                image_decoding_end_time = time.time()
+
+                output = self._image_processor.numpy_to_pil(self._image_processor.pt_to_numpy(image))
+
+                end_time = time.time()
+
+                logger.info(f"prompt encoding duration: {prompt_encoding_end_time - prompt_encoding_start_time}")
+                logger.info(f"denoising duration: {denoising_end_time - denoising_start_time}")
+                logger.info(f"image decoding duration: {image_decoding_end_time - image_decoding_start_time}")
+                logger.info(f"total runtime: {end_time - start_time}")
+
+        return output
+
+    def _step(
+        self,
+        *,
+        do_classifier_free_guidance: bool,
+        guidance_scale: float,
+        latents: List[ttnn.Tensor],  # device tensor
+        timestep: List[ttnn.Tensor],  # host tensor
+        pooled_prompt_embeds: List[ttnn.Tensor],  # device tensor
+        prompt_embeds: List[ttnn.Tensor],  # device tensor
+        sigma_difference: List[ttnn.Tensor],  # device tensor
+        prompt_sequence_length: int,
+        spatial_sequence_length: int,
+        traced: bool,
+    ) -> List[ttnn.Tensor]:
+        def inner(latent, prompt, pooled_projection, timestep, cfg_index):
+            # Use the new SD3Transformer2DModel interface
+            noise_pred = self.transformers[cfg_index](
+                hidden_states=latent,
+                encoder_hidden_states=prompt,
+                timestep=timestep,
+                pooled_projection=pooled_projection,
+                seq_len=spatial_sequence_length,
+                context_seq_len=prompt_sequence_length,
+            )
+            return noise_pred
+
+        # Collect noise predictions from all submesh devices
+        noise_pred_list = []
+        for submesh_id, submesh_device in enumerate(self.submesh_devices):
+            noise_pred = inner(
+                latents[submesh_id],
+                prompt_embeds[submesh_id],
+                pooled_prompt_embeds[submesh_id],
+                timestep[submesh_id],
+                submesh_id,
+            )
+            noise_pred_list.append(noise_pred)
+
+        # Apply CFG logic after collecting all predictions
+        if do_classifier_free_guidance:
+            if not self.dit_parallel_config.cfg_parallel.factor > 1:
+                # Single device case - direct operations work
+                split_pos = noise_pred_list[0].shape[0] // 2
+                uncond = noise_pred_list[0][0:split_pos]
+                cond = noise_pred_list[0][split_pos:]
+                noise_pred_list[0] = uncond + guidance_scale * (cond - uncond)
+            else:
+                # Multi-device case - move to CPU first
+                uncond = ttnn.to_torch(ttnn.get_device_tensors(noise_pred_list[0])[0].cpu(blocking=True)).to(
+                    torch.float32
+                )
+                cond = ttnn.to_torch(ttnn.get_device_tensors(noise_pred_list[1])[0].cpu(blocking=True)).to(
+                    torch.float32
+                )
+
+                torch_noise_pred = uncond + guidance_scale * (cond - uncond)
+
+                # Convert back to TTNN and redistribute to devices
+                shard_latents_dims = [None, None]
+                shard_latents_dims[self.dit_parallel_config.sequence_parallel.mesh_axis] = 2
+                noise_pred_list[0] = ttnn.from_torch(
+                    torch_noise_pred,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=self.submesh_devices[0],
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        self.submesh_devices[0],
+                        tuple(self.submesh_devices[0].shape),
+                        dims=shard_latents_dims,
+                    ),
+                )
+                noise_pred_list[1] = ttnn.from_torch(
+                    torch_noise_pred,
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=ttnn.bfloat16,
+                    device=self.submesh_devices[1],
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        self.submesh_devices[1],
+                        tuple(self.submesh_devices[1].shape),
+                        dims=shard_latents_dims,
+                    ),
+                )
+
+        # Apply flow matching step to each submesh
+        for submesh_id, submesh_device in enumerate(self.submesh_devices):
+            # Convert noise_pred from TTNN to torch for unpatchify
+            noise_pred_torch = ttnn.to_torch(ttnn.from_device(noise_pred_list[submesh_id]))
+
+            # Unpatchify velocity prediction to spatial format
+            latent_h = latents[submesh_id].shape[1]  # Height in NHWC
+            latent_w = latents[submesh_id].shape[2]  # Width in NHWC
+
+            velocity_spatial = self.transformers[0].unpatchify(noise_pred_torch, latent_h, latent_w)
+
+            # Convert back to TTNN on same device as input
+            velocity_ttnn = ttnn.from_torch(
+                velocity_spatial.permute(0, 2, 3, 1),  # NCHW -> NHWC
+                dtype=ttnn.bfloat16,
+                device=submesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+            # Apply flow matching step: latents = latents + dt * velocity
+            updated_latents = latents[submesh_id] + sigma_difference[submesh_id] * velocity_ttnn
+            latents[submesh_id] = updated_latents
+
+        return latents
+
+    def _encode_prompts(
+        self,
+        prompt_1: list[str],
+        prompt_2: list[str],
+        prompt_3: list[str],
+        negative_prompt_1: list[str],
+        negative_prompt_2: list[str],
+        negative_prompt_3: list[str],
+        num_images_per_prompt: int,
+        max_t5_sequence_length: int,
+        do_classifier_free_guidance: bool,
+        clip_skip: int | None,
+    ):
+        """Encode prompts using CLIP and T5 text encoders"""
+        # This method is identical to the Large pipeline
+        # Reuse the same text encoding logic
+        from ...pipelines.stable_diffusion_35_large.pipeline_stable_diffusion_35_large import (
+            _get_clip_prompt_embeds,
+            _get_t5_prompt_embeds,
+        )
+
+        timer = self.timing_collector
+
+        tokenizer_max_length = self._tokenizer_1.model_max_length
+
+        with timer.time_section("clip_encoding") if timer else nullcontext():
+            prompt_embed, pooled_prompt_embed = _get_clip_prompt_embeds(
+                prompt=prompt_1,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_1,
+                text_encoder=self._text_encoder_1,
+                tokenizer_max_length=tokenizer_max_length,
+                ttnn_device=self.encoder_device,
+                encoder_parallel_config=self.encoder_parallel_config,
+                clip_skip=clip_skip,
+            )
+
+            prompt_2_embed, pooled_prompt_2_embed = _get_clip_prompt_embeds(
+                prompt=prompt_2,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_2,
+                text_encoder=self._text_encoder_2,
+                tokenizer_max_length=tokenizer_max_length,
+                ttnn_device=self.encoder_device,
+                encoder_parallel_config=self.encoder_parallel_config,
+                clip_skip=clip_skip,
+            )
+            clip_prompt_embeds = torch.cat([prompt_embed, prompt_2_embed], dim=-1)
+
+        with timer.time_section("t5_encoding") if timer else nullcontext():
+            t5_prompt_embed = _get_t5_prompt_embeds(
+                device=self.encoder_device,
+                encoder_parallel_config=self.encoder_parallel_config,
+                prompt=prompt_3,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_t5_sequence_length,
+                tokenizer=self._tokenizer_3,
+                text_encoder=self._text_encoder_3,
+                tokenizer_max_length=tokenizer_max_length,
+                joint_attention_dim=self._joint_attention_dim,
+            )
+
+        clip_prompt_embeds = torch.nn.functional.pad(
+            clip_prompt_embeds,
+            (0, t5_prompt_embed.shape[-1] - clip_prompt_embeds.shape[-1]),
+        )
+
+        prompt_embeds = torch.cat([clip_prompt_embeds, t5_prompt_embed], dim=-2)
+        pooled_prompt_embeds = torch.cat([pooled_prompt_embed, pooled_prompt_2_embed], dim=-1)
+
+        if not do_classifier_free_guidance:
+            return prompt_embeds, pooled_prompt_embeds
+
+        with timer.time_section("clip_encoding") if timer else nullcontext():
+            negative_prompt_embed, negative_pooled_prompt_embed = _get_clip_prompt_embeds(
+                prompt=negative_prompt_1,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_1,
+                text_encoder=self._text_encoder_1,
+                tokenizer_max_length=tokenizer_max_length,
+                encoder_parallel_config=self.encoder_parallel_config,
+                ttnn_device=self.encoder_device,
+                clip_skip=clip_skip,
+            )
+            negative_prompt_2_embed, negative_pooled_prompt_2_embed = _get_clip_prompt_embeds(
+                prompt=negative_prompt_2,
+                num_images_per_prompt=num_images_per_prompt,
+                tokenizer=self._tokenizer_2,
+                text_encoder=self._text_encoder_2,
+                tokenizer_max_length=tokenizer_max_length,
+                encoder_parallel_config=self.encoder_parallel_config,
+                ttnn_device=self.encoder_device,
+                clip_skip=clip_skip,
+            )
+            negative_clip_prompt_embeds = torch.cat([negative_prompt_embed, negative_prompt_2_embed], dim=-1)
+
+        with timer.time_section("t5_encoding") if timer else nullcontext():
+            t5_negative_prompt_embed = _get_t5_prompt_embeds(
+                device=self.encoder_device,
+                encoder_parallel_config=self.encoder_parallel_config,
+                prompt=negative_prompt_3,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_t5_sequence_length,
+                tokenizer=self._tokenizer_3,
+                text_encoder=self._text_encoder_3,
+                tokenizer_max_length=tokenizer_max_length,
+                joint_attention_dim=self._joint_attention_dim,
+            )
+
+        negative_clip_prompt_embeds = torch.nn.functional.pad(
+            negative_clip_prompt_embeds,
+            (
+                0,
+                t5_negative_prompt_embed.shape[-1] - negative_clip_prompt_embeds.shape[-1],
+            ),
+        )
+
+        negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
+        negative_pooled_prompt_embeds = torch.cat(
+            [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+        )
+
+        prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+        pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
+
+        return prompt_embeds, pooled_prompt_embeds
+
+    def _vae_decode(self, tt_latents, width, height):
+        """Decode latents using VAE decoder"""
+        ttnn.synchronize_device(self.vae_device)
+
+        tt_latents = self.ccl_managers[self.vae_submesh_idx].all_gather_persistent_buffer(
+            tt_latents, dim=2, mesh_axis=self.dit_parallel_config.sequence_parallel.mesh_axis
+        )
+
+        # Latents are in NHWC format [B, H, W, C] - keep NHWC for TT VAE decoder
+        torch_latents = ttnn.to_torch(ttnn.get_device_tensors(tt_latents)[0])
+
+        # Remove extra dimensions, keep NHWC format
+        while torch_latents.dim() > 4:
+            torch_latents = torch_latents.squeeze(0)
+
+        # Apply VAE scaling (in NHWC format)
+        logger.debug(
+            f"Latents before VAE scaling: min={torch_latents.min():.4f}, max={torch_latents.max():.4f}, mean={torch_latents.mean():.4f}"
+        )
+
+        # Re-center latents to compensate for accumulated numerical drift
+        # This helps correct the color/brightness bias from accumulated error
+        latent_mean = torch_latents.mean()
+        if abs(latent_mean) > 0.05:  # Only correct if significant drift
+            logger.debug(f"Correcting latent mean drift: {latent_mean:.4f}")
+            torch_latents = torch_latents - latent_mean
+
+        torch_latents = (torch_latents / self._torch_vae_scaling_factor) + self._torch_vae_shift_factor
+        logger.debug(
+            f"Latents after VAE scaling: min={torch_latents.min():.4f}, max={torch_latents.max():.4f}, mean={torch_latents.mean():.4f}"
+        )
+
+        if self.desired_encoder_submesh_shape != self.original_submesh_shape:
+            # HACK: reshape submesh device 0 from 2D to 1D
+            # If reshaping, vae device is same as encoder device
+            self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
+
+        tt_latents = ttnn.from_torch(
+            torch_latents,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            device=None,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.vae_device),
+        )
+
+        if self._vae_input_latents is None:
+            self._vae_input_latents = tt_latents.to(self.vae_device)
+        else:
+            ttnn.copy_host_to_device_tensor(tt_latents, self._vae_input_latents)
+
+        decoded_output = self._vae_decoder(self._vae_input_latents)
+        return decoded_output
+
+    def t5_enabled(self):
+        """Check if T5 text encoder is enabled"""
+        return self._text_encoder_3 is not None
+
+
+# Helper functions adapted from SD3.5 Large pipeline
+def _get_clip_prompt_embeds(
+    *,
+    clip_skip: int | None = None,
+    device: torch.device | None = None,
+    ttnn_device: ttnn.Device | None = None,
+    encoder_parallel_config: EncoderParallelConfig | None = None,
+    num_images_per_prompt: int,
+    prompt: list[str],
+    text_encoder: CLIPEncoder,
+    tokenizer_max_length: int,
+    tokenizer: CLIPTokenizer,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Get CLIP prompt embeddings"""
+    batch_size = len(prompt)
+
+    text_inputs = tokenizer(
+        prompt,
+        padding="max_length",
+        max_length=tokenizer_max_length,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    text_input_ids = text_inputs.input_ids
+    untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
+    if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
+        removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer_max_length - 1 : -1])
+        logger.warning(
+            "The following part of your input was truncated because CLIP can only handle sequences up to"
+            f" {tokenizer_max_length} tokens: {removed_text}"
+        )
+
+    tt_text_input_ids = ttnn.from_torch(
+        text_input_ids,
+        dtype=ttnn.uint32,
+        layout=ttnn.TILE_LAYOUT,
+        device=ttnn_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_device),
+    )
+
+    # Call the CLIPEncoder with projection enabled
+    encoder_output, projected_output = text_encoder(
+        prompt_tokenized=tt_text_input_ids,
+        mesh_device=ttnn_device,
+        with_projection=True,
+    )
+
+    # Handle clip_skip by selecting the appropriate hidden state layer
+    if clip_skip is None:
+        # Use the second-to-last layer (like the original implementation)
+        sequence_embeddings = encoder_output[-2]
+    else:
+        layer_index = -(clip_skip + 2)
+        if abs(layer_index) > len(encoder_output):
+            layer_index = -2
+        sequence_embeddings = encoder_output[layer_index]
+
+    prompt_embeds = ttnn.to_torch(ttnn.get_device_tensors(sequence_embeddings)[0])
+
+    pooled_prompt_embeds = ttnn.to_torch(ttnn.get_device_tensors(projected_output)[0])
+
+    prompt_embeds = prompt_embeds.to(device=device)
+    pooled_prompt_embeds = pooled_prompt_embeds.to(device=device)
+
+    _, seq_len, _ = prompt_embeds.shape
+    # duplicate text embeddings for each generation per prompt, using mps friendly method
+    prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
+
+    pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, -1)
+
+    return prompt_embeds, pooled_prompt_embeds
+
+
+def _get_t5_prompt_embeds(
+    prompt: list[str],
+    *,
+    torch_device: torch.device | None = None,
+    device: ttnn.Device,
+    encoder_parallel_config: EncoderParallelConfig | None = None,
+    joint_attention_dim: int,
+    max_sequence_length: int,
+    num_images_per_prompt: int,
+    text_encoder: T5Encoder | None,
+    tokenizer_max_length: int,
+    tokenizer: T5TokenizerFast,
+) -> torch.Tensor:
+    """Get T5 prompt embeddings"""
+    prompt = [prompt] if isinstance(prompt, str) else prompt
+    batch_size = len(prompt)
+
+    if text_encoder is None:
+        return torch.zeros(
+            (
+                batch_size * num_images_per_prompt,
+                tokenizer_max_length,
+                joint_attention_dim,
+            ),
+            device=torch_device,
+            dtype=torch.bfloat16,
+        )
+
+    text_inputs = tokenizer(
+        prompt,
+        padding="max_length",
+        max_length=max_sequence_length,
+        truncation=True,
+        add_special_tokens=True,
+        return_tensors="pt",
+    )
+    text_input_ids = text_inputs.input_ids
+    untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
+
+    if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
+        removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer_max_length - 1 : -1])
+        logger.warning(
+            "The following part of your input was truncated because `max_sequence_length` is set to "
+            f" {max_sequence_length} tokens: {removed_text}"
+        )
+
+    tt_text_input_ids = ttnn.from_torch(
+        text_input_ids,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+    # Call the T5Encoder
+    hidden_states = text_encoder(prompt=tt_text_input_ids, device=device)
+
+    # Use the final layer output (last element in the list)
+    tt_prompt_embeds = hidden_states[-1]
+    tt_prompt_embeds = ttnn.get_device_tensors(tt_prompt_embeds)[0]
+    prompt_embeds = ttnn.to_torch(tt_prompt_embeds)
+
+    prompt_embeds = prompt_embeds.to(device=torch_device)
+
+    _, seq_len, _ = prompt_embeds.shape
+
+    # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
+    prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    return prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)

--- a/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
+++ b/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -19,16 +19,26 @@ from loguru import logger
 from transformers import CLIPTextModelWithProjection, CLIPTokenizer, T5EncoderModel, T5TokenizerFast
 from contextlib import contextmanager, nullcontext
 
-from ...encoders.clip.model_clip import CLIPEncoder, CLIPConfig
-from ...encoders.t5.model_t5 import T5Encoder, T5Config
+from models.experimental.tt_dit.encoders.clip.model_clip import CLIPEncoder, CLIPConfig
+from models.experimental.tt_dit.encoders.t5.model_t5 import T5Encoder, T5Config
 
 # Import SD3.5 Medium transformer
-from ...models.transformers.sd35_med.transformer_sd35_medium import SD3Transformer2DModel
-from ...models.vae.vae_sd35 import VAEDecoder
-from ...parallel.manager import CCLManager
-from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, VAEParallelConfig, ParallelFactor
-from ...utils.padding import PaddingConfig
-from ...utils.cache import save_cache_dict, load_cache_dict, cache_dict_exists, get_and_create_cache_path
+from models.experimental.tt_dit.models.transformers.sd35_med.transformer_sd35_medium import SD3Transformer2DModel
+from models.experimental.tt_dit.models.vae.vae_sd35 import VAEDecoder
+from models.experimental.tt_dit.parallel.manager import CCLManager
+from models.experimental.tt_dit.parallel.config import (
+    DiTParallelConfig,
+    EncoderParallelConfig,
+    VAEParallelConfig,
+    ParallelFactor,
+)
+from models.experimental.tt_dit.utils.padding import PaddingConfig
+from models.experimental.tt_dit.utils.cache import (
+    save_cache_dict,
+    load_cache_dict,
+    cache_dict_exists,
+    get_and_create_cache_path,
+)
 
 TILE_SIZE = 32
 
@@ -122,7 +132,6 @@ class StableDiffusion3MediumPipeline:
             CCLManager(submesh_device, num_links=num_links, topology=ttnn.Topology.Linear)
             for submesh_device in self.submesh_devices
         ]
-        # Hacky submesh reshapes and assignment to parallelize encoders and VAE
         encoder_device = self.submesh_devices[0]
         self.original_submesh_shape = tuple(encoder_device.shape)
         self.desired_encoder_submesh_shape = tuple(encoder_device.shape)
@@ -130,12 +139,10 @@ class StableDiffusion3MediumPipeline:
         # Determine the number of devices available for parallelization
         num_devices = encoder_device.shape[0] * encoder_device.shape[1]
 
-        # Use factor=1 for minimal test configurations, factor=4 for production
         encoder_tp_factor = 4 if num_devices >= 4 else 1
         vae_tp_factor = 4 if num_devices >= 4 else 1
 
         if encoder_device.shape[1] != encoder_tp_factor and num_devices >= encoder_tp_factor:
-            # If reshaping, vae_device must be on submesh 0. That means T5 can't fit, so disable it.
             vae_submesh_idx = 0
             if enable_t5_text_encoder:
                 logger.warning(
@@ -151,7 +158,6 @@ class StableDiffusion3MediumPipeline:
             self.desired_encoder_submesh_shape = (1, encoder_tp_factor)
 
         else:
-            # vae_device can only be on submesh 1 if submesh is not getting reshaped.
             vae_submesh_idx = 1 if len(self.submesh_devices) > 1 else 0
         vae_device = self.submesh_devices[vae_submesh_idx]
 
@@ -187,10 +193,10 @@ class StableDiffusion3MediumPipeline:
         torch_transformer = TorchSD3Transformer2DModel.from_pretrained(
             model_checkpoint_path,
             subfolder="transformer",
-            torch_dtype=torch.bfloat16,  # bfloat16 is the native datatype of the model
+            torch_dtype=torch.bfloat16,
         )
         torch_transformer.eval()
-        print("torch_transformer: ", torch_transformer)
+        logger.debug("Loaded torch transformer")
 
         assert isinstance(self._tokenizer_1, CLIPTokenizer)
         assert isinstance(self._tokenizer_2, CLIPTokenizer)
@@ -228,14 +234,13 @@ class StableDiffusion3MediumPipeline:
         pos_embed_max_size = getattr(transformer_config, "pos_embed_max_size", 192)
         transformer_depth = getattr(transformer_config, "num_layers", 24)
 
-        # Set patch_size early since it's used in transformer creation
+        # Set patch_size
         self.patch_size = patch_size
 
         logger.info(f"Using transformer depth={transformer_depth}")
 
         self.transformers = []
         for i, submesh_device in enumerate(self.submesh_devices):
-            # Use the new SD3Transformer2DModel implementation
             tt_transformer = SD3Transformer2DModel(
                 sample_size=sample_size,
                 patch_size=patch_size,
@@ -287,7 +292,6 @@ class StableDiffusion3MediumPipeline:
         self._image_processor = VaeImageProcessor(vae_scale_factor=self._torch_vae_scale_factor)
 
         if self.desired_encoder_submesh_shape != self.original_submesh_shape:
-            # HACK: reshape submesh device 0 to 1D
             self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
 
         logger.info("creating TT-NN CLIP text encoder...")
@@ -326,17 +330,17 @@ class StableDiffusion3MediumPipeline:
         self._text_encoder_1 = CLIPEncoder(
             config=clip_config_1,
             mesh_device=encoder_device,
-            ccl_manager=self.ccl_managers[0],  # use CCL manager for submesh 0
+            ccl_manager=self.ccl_managers[0],
             parallel_config=encoder_parallel_config,
-            eos_token_id=2,  # default EOS token ID for CLIP
+            eos_token_id=2,
         )
 
         self._text_encoder_2 = CLIPEncoder(
             config=clip_config_2,
             mesh_device=encoder_device,
-            ccl_manager=self.ccl_managers[0],  # Use CCL manager for submesh 0
+            ccl_manager=self.ccl_managers[0],
             parallel_config=encoder_parallel_config,
-            eos_token_id=2,  # default EOS token ID for CLIP
+            eos_token_id=2,
         )
 
         # Load state dicts into new encoders
@@ -354,20 +358,20 @@ class StableDiffusion3MediumPipeline:
                 kv_dim=torch_text_encoder_3.config.d_kv,
                 num_heads=torch_text_encoder_3.config.num_heads,
                 num_hidden_layers=torch_text_encoder_3.config.num_layers,
-                max_prompt_length=256,  # default T5 max prompt length
+                max_prompt_length=256,
                 layer_norm_eps=torch_text_encoder_3.config.layer_norm_epsilon,
                 relative_attention_num_buckets=torch_text_encoder_3.config.relative_attention_num_buckets,
                 relative_attention_max_distance=torch_text_encoder_3.config.relative_attention_max_distance,
             )
 
-            # Store original state dict before creating new encoder
+            # Store original state dict
             torch_text_encoder_3_state_dict = torch_text_encoder_3.state_dict()
 
             # Create new T5 encoder
             self._text_encoder_3 = T5Encoder(
                 config=t5_config,
                 mesh_device=encoder_device,
-                ccl_manager=self.ccl_managers[0],  # use CCL manager for submesh 0
+                ccl_manager=self.ccl_managers[0],
                 parallel_config=encoder_parallel_config,
             )
 
@@ -376,7 +380,7 @@ class StableDiffusion3MediumPipeline:
         else:
             self._text_encoder_3 = None
 
-        self.timing_collector = None  # Set externally when timing is needed
+        self.timing_collector = None
 
         self._trace = None
 
@@ -395,8 +399,6 @@ class StableDiffusion3MediumPipeline:
         )
 
         if self.desired_encoder_submesh_shape != self.original_submesh_shape:
-            # HACK: reshape submesh device 0 to 1D
-            # If reshaping, vae device is same as encoder device
             self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
 
     def prepare(
@@ -458,7 +460,6 @@ class StableDiffusion3MediumPipeline:
         guidance_cond = 2 if (guidance_scale > 1 and cfg_factor == 1) else 1
 
         # Enable T5 based on device configuration
-        # T5 is disabled if mesh needs reshaping for CLIP encoder
         submesh_shape = list(mesh_device.shape)
         submesh_shape[cfg_axis] //= cfg_factor
         enable_t5_text_encoder = submesh_shape[1] == 4  # T5 only works if submesh doesn't need reshaping
@@ -526,7 +527,7 @@ class StableDiffusion3MediumPipeline:
         with timer.time_section("total") if timer else nullcontext():
             start_time = time.time()
 
-            # Auto-call prepare() with defaults if not already called
+            # Auto-call prepare() with defaults
             if not hasattr(self, "_prepared_batch_size"):
                 batch_size = len(prompt_1)
                 self.prepare(
@@ -553,8 +554,7 @@ class StableDiffusion3MediumPipeline:
             assert batch_size == len(prompt_1)
 
             do_classifier_free_guidance = guidance_scale > 1
-            # TODO: pass the patch_size value
-            patch_size = 2
+            patch_size = self.patch_size
             latents_shape = (
                 batch_size * num_images_per_prompt,
                 height // self._torch_vae_scale_factor,
@@ -562,13 +562,12 @@ class StableDiffusion3MediumPipeline:
                 self._num_channels_latents,
             )
 
-            print(f"Latents shape: {latents_shape}")
+            logger.debug(f"Latents shape: {latents_shape}")
 
             logger.info("encoding prompts...")
 
             with timer.time_section("total_encoding") if timer else nullcontext():
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
-                    # HACK: reshape submesh device 0 from 2D to 1D
                     self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
                 prompt_encoding_start_time = time.time()
                 prompt_embeds, pooled_prompt_embeds = self._encode_prompts(
@@ -584,7 +583,6 @@ class StableDiffusion3MediumPipeline:
                     clip_skip=clip_skip,
                 )
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
-                    # HACK: reshape submesh device 0 from 1D to 2D
                     self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
                 prompt_encoding_end_time = time.time()
                 logger.info("preparing timesteps...")
@@ -596,8 +594,6 @@ class StableDiffusion3MediumPipeline:
 
             if seed is not None:
                 torch.manual_seed(seed)
-            # Latents shape is (batch_size * num_images_per_prompt, H, W, C) in NHWC format
-            # TTNN SD3Transformer2DModel expects NHWC format (same as latents_shape)
             latents = torch.randn(latents_shape, dtype=prompt_embeds.dtype)
 
             tt_prompt_embeds_list = []
@@ -696,7 +692,7 @@ class StableDiffusion3MediumPipeline:
                             fill_value=t,
                             layout=ttnn.TILE_LAYOUT,
                             dtype=ttnn.float32,
-                            device=submesh_device,  # Always create on device
+                            device=submesh_device,
                         )
                         tt_timestep_list.append(tt_timestep)
 
@@ -706,7 +702,7 @@ class StableDiffusion3MediumPipeline:
                                 fill_value=sigma_difference,
                                 layout=ttnn.TILE_LAYOUT,
                                 dtype=ttnn.bfloat16,
-                                device=submesh_device,  # Create on device
+                                device=submesh_device,
                             )
                         )
 
@@ -725,7 +721,7 @@ class StableDiffusion3MediumPipeline:
 
                     tt_latents_step_list = self._step(
                         timestep=tt_timestep_list,
-                        latents=tt_latents_step_list,  # tt_latents,
+                        latents=tt_latents_step_list,
                         do_classifier_free_guidance=do_classifier_free_guidance,
                         prompt_embeds=tt_prompt_embeds_list,
                         pooled_prompt_embeds=tt_pooled_prompt_embeds_list,
@@ -748,13 +744,11 @@ class StableDiffusion3MediumPipeline:
                     f"VAE decoded output: min={decoded_output.min():.4f}, max={decoded_output.max():.4f}, mean={decoded_output.mean():.4f}"
                 )
 
-                # HACK: reshape submesh device 0 from 1D to 2D
                 if self.desired_encoder_submesh_shape != self.original_submesh_shape:
                     # If reshaping, vae device is same as encoder device
                     self.encoder_device.reshape(ttnn.MeshShape(*self.original_submesh_shape))
-                # image = self._torch_vae.decoder(tt_latents)
                 image = self._image_processor.postprocess(decoded_output, output_type="pt")
-                print(f"postprocessed image shape: {image.shape}")
+                logger.debug(f"Postprocessed image shape: {image.shape}")
                 assert isinstance(image, torch.Tensor)
                 image_decoding_end_time = time.time()
 
@@ -774,17 +768,16 @@ class StableDiffusion3MediumPipeline:
         *,
         do_classifier_free_guidance: bool,
         guidance_scale: float,
-        latents: List[ttnn.Tensor],  # device tensor
-        timestep: List[ttnn.Tensor],  # host tensor
-        pooled_prompt_embeds: List[ttnn.Tensor],  # device tensor
-        prompt_embeds: List[ttnn.Tensor],  # device tensor
-        sigma_difference: List[ttnn.Tensor],  # device tensor
+        latents: List[ttnn.Tensor],
+        timestep: List[ttnn.Tensor],
+        pooled_prompt_embeds: List[ttnn.Tensor],
+        prompt_embeds: List[ttnn.Tensor],
+        sigma_difference: List[ttnn.Tensor],
         prompt_sequence_length: int,
         spatial_sequence_length: int,
         traced: bool,
     ) -> List[ttnn.Tensor]:
         def inner(latent, prompt, pooled_projection, timestep, cfg_index):
-            # Use the new SD3Transformer2DModel interface
             noise_pred = self.transformers[cfg_index](
                 hidden_states=latent,
                 encoder_hidden_states=prompt,
@@ -807,7 +800,7 @@ class StableDiffusion3MediumPipeline:
             )
             noise_pred_list.append(noise_pred)
 
-        # Apply CFG logic after collecting all predictions
+        # Apply CFG logic
         if do_classifier_free_guidance:
             if not self.dit_parallel_config.cfg_parallel.factor > 1:
                 # Single device case - direct operations work
@@ -816,7 +809,6 @@ class StableDiffusion3MediumPipeline:
                 cond = noise_pred_list[0][split_pos:]
                 noise_pred_list[0] = uncond + guidance_scale * (cond - uncond)
             else:
-                # Multi-device case - move to CPU first
                 uncond = ttnn.to_torch(ttnn.get_device_tensors(noise_pred_list[0])[0].cpu(blocking=True)).to(
                     torch.float32
                 )
@@ -858,14 +850,14 @@ class StableDiffusion3MediumPipeline:
             noise_pred_torch = ttnn.to_torch(ttnn.from_device(noise_pred_list[submesh_id]))
 
             # Unpatchify velocity prediction to spatial format
-            latent_h = latents[submesh_id].shape[1]  # Height in NHWC
-            latent_w = latents[submesh_id].shape[2]  # Width in NHWC
+            latent_h = latents[submesh_id].shape[1]
+            latent_w = latents[submesh_id].shape[2]
 
             velocity_spatial = self.transformers[0].unpatchify(noise_pred_torch, latent_h, latent_w)
 
             # Convert back to TTNN on same device as input
             velocity_ttnn = ttnn.from_torch(
-                velocity_spatial.permute(0, 2, 3, 1),  # NCHW -> NHWC
+                velocity_spatial.permute(0, 2, 3, 1),
                 dtype=ttnn.bfloat16,
                 device=submesh_device,
                 layout=ttnn.TILE_LAYOUT,
@@ -892,8 +884,6 @@ class StableDiffusion3MediumPipeline:
         clip_skip: int | None,
     ):
         """Encode prompts using CLIP and T5 text encoders"""
-        # This method is identical to the Large pipeline
-        # Reuse the same text encoding logic
         from ...pipelines.stable_diffusion_35_large.pipeline_stable_diffusion_35_large import (
             _get_clip_prompt_embeds,
             _get_t5_prompt_embeds,
@@ -1013,10 +1003,10 @@ class StableDiffusion3MediumPipeline:
             tt_latents, dim=2, mesh_axis=self.dit_parallel_config.sequence_parallel.mesh_axis
         )
 
-        # Latents are in NHWC format [B, H, W, C] - keep NHWC for TT VAE decoder
+        # Latents are in NHWC format [B, H, W, C]
         torch_latents = ttnn.to_torch(ttnn.get_device_tensors(tt_latents)[0])
 
-        # Remove extra dimensions, keep NHWC format
+        # Remove extra dimensions
         while torch_latents.dim() > 4:
             torch_latents = torch_latents.squeeze(0)
 
@@ -1026,9 +1016,8 @@ class StableDiffusion3MediumPipeline:
         )
 
         # Re-center latents to compensate for accumulated numerical drift
-        # This helps correct the color/brightness bias from accumulated error
         latent_mean = torch_latents.mean()
-        if abs(latent_mean) > 0.05:  # Only correct if significant drift
+        if abs(latent_mean) > 0.05:
             logger.debug(f"Correcting latent mean drift: {latent_mean:.4f}")
             torch_latents = torch_latents - latent_mean
 
@@ -1038,7 +1027,6 @@ class StableDiffusion3MediumPipeline:
         )
 
         if self.desired_encoder_submesh_shape != self.original_submesh_shape:
-            # HACK: reshape submesh device 0 from 2D to 1D
             # If reshaping, vae device is same as encoder device
             self.encoder_device.reshape(ttnn.MeshShape(*self.desired_encoder_submesh_shape))
 
@@ -1113,7 +1101,7 @@ def _get_clip_prompt_embeds(
 
     # Handle clip_skip by selecting the appropriate hidden state layer
     if clip_skip is None:
-        # Use the second-to-last layer (like the original implementation)
+        # Use the second-to-last layer
         sequence_embeddings = encoder_output[-2]
     else:
         layer_index = -(clip_skip + 2)
@@ -1196,7 +1184,7 @@ def _get_t5_prompt_embeds(
     # Call the T5Encoder
     hidden_states = text_encoder(prompt=tt_text_input_ids, device=device)
 
-    # Use the final layer output (last element in the list)
+    # Use the final layer output
     tt_prompt_embeds = hidden_states[-1]
     tt_prompt_embeds = ttnn.get_device_tensors(tt_prompt_embeds)[0]
     prompt_embeds = ttnn.to_torch(tt_prompt_embeds)
@@ -1205,6 +1193,6 @@ def _get_t5_prompt_embeds(
 
     _, seq_len, _ = prompt_embeds.shape
 
-    # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
+    # duplicate text embeddings and attention mask for each generation per prompt
     prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
     return prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)

--- a/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
+++ b/models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py
@@ -24,7 +24,7 @@ from models.experimental.tt_dit.encoders.t5.model_t5 import T5Encoder, T5Config
 
 # Import SD3.5 Medium transformer
 from models.experimental.tt_dit.models.transformers.sd35_med.transformer_sd35_medium import SD3Transformer2DModel
-from models.experimental.tt_dit.models.vae.vae_sd35 import VAEDecoder
+from models.experimental.tt_dit.models.vae.vae_sd35_med import VAEDecoder
 from models.experimental.tt_dit.parallel.manager import CCLManager
 from models.experimental.tt_dit.parallel.config import (
     DiTParallelConfig,

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -34,9 +34,6 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
     )
     torch_transformer.eval()
 
-    # Extract attention layer from the transformer model
-    # Access the first transformer block's attention layer
-    # Structure: transformer.transformer_blocks[0].attn
     if not hasattr(torch_transformer, "transformer_blocks") or len(torch_transformer.transformer_blocks) == 0:
         raise ValueError("Could not find transformer_blocks in the loaded model")
 
@@ -77,10 +74,7 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
     except Exception as e:
         logger.warning(f"Could not load state dict directly: {e}")
         logger.info("Attempting to extract weights manually...")
-        # Try to extract weights manually if direct loading fails
-        # The diffusers Attention class might have different weight names
         if hasattr(reference_model, "to_q") and hasattr(reference_model, "to_k") and hasattr(reference_model, "to_v"):
-            # Handle diffusers Attention structure (separate q, k, v projections)
             logger.info("Found separate q, k, v projections in attention layer")
         elif hasattr(reference_model, "to_qkv"):
             logger.info("Found fused qkv projection in attention layer")
@@ -90,12 +84,8 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
     # Create input
     x_input = torch.randn(1, batch_size, seq_len, dim, dtype=torch.bfloat16)
 
-    # Reference forward - the diffusers Attention layer expects specific input format
-    # It typically expects: (hidden_states, encoder_hidden_states=None, ...)
     with torch.no_grad():
         try:
-            # Try calling the attention layer directly with the input
-            # Diffusers Attention usually expects (batch, seq_len, hidden_dim)
             ref_output = reference_model(x_input.squeeze(0))
             logger.info(f"Reference forward successful. Output shape: {ref_output.shape}")
         except Exception as e:

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.experimental.tt_dit.models.transformers.sd35_med.attention_sd35_medium import SD35MediumSelfAttention
@@ -17,7 +16,6 @@ from diffusers.models.transformers.transformer_sd3 import SD3Transformer2DModel 
         (1536, 24, 1024, 1),
         (1536, 24, 512, 1),
     ],
-    # ids=["sd35_med_512"],
     ids=["sd35_med_1k", "sd35_med_512"],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
@@ -47,13 +45,6 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
     reference_model = first_block.attn
     reference_model.eval()
 
-    # Print the attention model structure
-    print("=" * 80)
-    print("SD3.5 Medium Attention Model (from Stability AI pipeline):")
-    print("=" * 80)
-    print(reference_model)
-    print("=" * 80)
-
     # Create TTNN model
     tt_model = SD35MediumSelfAttention(
         dim=dim,
@@ -68,18 +59,9 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
     # Load weights from the extracted attention layer
     try:
         state_dict = reference_model.state_dict()
-        logger.info(f"Attention layer state dict keys: {list(state_dict.keys())}")
         tt_model.load_state_dict(state_dict)
-        logger.info("Successfully loaded weights from Stability AI attention layer")
     except Exception as e:
-        logger.warning(f"Could not load state dict directly: {e}")
-        logger.info("Attempting to extract weights manually...")
-        if hasattr(reference_model, "to_q") and hasattr(reference_model, "to_k") and hasattr(reference_model, "to_v"):
-            logger.info("Found separate q, k, v projections in attention layer")
-        elif hasattr(reference_model, "to_qkv"):
-            logger.info("Found fused qkv projection in attention layer")
-        elif hasattr(reference_model, "qkv"):
-            logger.info("Found qkv projection in attention layer")
+        raise ValueError(f"Could not load state dict: {e}")
 
     # Create input
     x_input = torch.randn(1, batch_size, seq_len, dim, dtype=torch.bfloat16)
@@ -87,21 +69,10 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
     with torch.no_grad():
         try:
             ref_output = reference_model(x_input.squeeze(0))
-            logger.info(f"Reference forward successful. Output shape: {ref_output.shape}")
-        except Exception as e:
-            logger.warning(f"Direct forward failed: {e}")
-            logger.info(
-                f"Attention layer forward signature might be different. Trying with encoder_hidden_states=None..."
-            )
+        except Exception:
             try:
-                # Some attention layers need encoder_hidden_states parameter
                 ref_output = reference_model(x_input.squeeze(0), encoder_hidden_states=None)
-                logger.info(
-                    f"Reference forward successful with encoder_hidden_states=None. Output shape: {ref_output.shape}"
-                )
-            except Exception as e2:
-                logger.warning(f"Forward with encoder_hidden_states=None also failed: {e2}")
-                logger.info("Skipping reference forward for now")
+            except Exception:
                 ref_output = None
 
     # TTNN forward
@@ -113,7 +84,4 @@ def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size,
 
     if ref_output is not None:
         passing, pcc = comp_pcc(ref_output, tt_output_torch, 0.99)
-        logger.info(f"Self-Attention PCC: {pcc}")
         assert passing, f"PCC check failed: {pcc}"
-    else:
-        logger.warning("Skipping PCC check as reference forward was not successful")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.experimental.tt_dit.models.transformers.sd35_med.attention_sd35_medium import SD35MediumSelfAttention
+from diffusers.models.transformers.transformer_sd3 import SD3Transformer2DModel as TorchSD3Transformer2DModel
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "dim, num_heads, seq_len, batch_size",
+    [
+        (1536, 24, 1024, 1),
+        (1536, 24, 512, 1),
+    ],
+    # ids=["sd35_med_512"],
+    ids=["sd35_med_1k", "sd35_med_512"],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+def test_sd35_medium_self_attention(device, dim, num_heads, seq_len, batch_size, dtype, reset_seeds):
+    """Test SD3.5 Medium self-attention matching MM-DiT reference"""
+    torch.manual_seed(1234)
+
+    # Load SD3.5 Medium transformer from Stability AI pipeline
+    model_checkpoint_path = "stabilityai/stable-diffusion-3.5-medium"
+    torch_transformer = TorchSD3Transformer2DModel.from_pretrained(
+        model_checkpoint_path,
+        subfolder="transformer",
+        torch_dtype=torch.bfloat16,
+    )
+    torch_transformer.eval()
+
+    # Extract attention layer from the transformer model
+    # Access the first transformer block's attention layer
+    # Structure: transformer.transformer_blocks[0].attn
+    if not hasattr(torch_transformer, "transformer_blocks") or len(torch_transformer.transformer_blocks) == 0:
+        raise ValueError("Could not find transformer_blocks in the loaded model")
+
+    first_block = torch_transformer.transformer_blocks[0]
+    if not hasattr(first_block, "attn"):
+        raise ValueError(
+            f"Could not find 'attn' attribute in transformer block. Available attributes: {dir(first_block)}"
+        )
+
+    # Extract just the attention layer
+    reference_model = first_block.attn
+    reference_model.eval()
+
+    # Print the attention model structure
+    print("=" * 80)
+    print("SD3.5 Medium Attention Model (from Stability AI pipeline):")
+    print("=" * 80)
+    print(reference_model)
+    print("=" * 80)
+
+    # Create TTNN model
+    tt_model = SD35MediumSelfAttention(
+        dim=dim,
+        num_heads=num_heads,
+        qkv_bias=True,
+        pre_only=False,
+        qk_norm="rms",
+        eps=1e-6,
+        mesh_device=device,
+    )
+
+    # Load weights from the extracted attention layer
+    try:
+        state_dict = reference_model.state_dict()
+        logger.info(f"Attention layer state dict keys: {list(state_dict.keys())}")
+        tt_model.load_state_dict(state_dict)
+        logger.info("Successfully loaded weights from Stability AI attention layer")
+    except Exception as e:
+        logger.warning(f"Could not load state dict directly: {e}")
+        logger.info("Attempting to extract weights manually...")
+        # Try to extract weights manually if direct loading fails
+        # The diffusers Attention class might have different weight names
+        if hasattr(reference_model, "to_q") and hasattr(reference_model, "to_k") and hasattr(reference_model, "to_v"):
+            # Handle diffusers Attention structure (separate q, k, v projections)
+            logger.info("Found separate q, k, v projections in attention layer")
+        elif hasattr(reference_model, "to_qkv"):
+            logger.info("Found fused qkv projection in attention layer")
+        elif hasattr(reference_model, "qkv"):
+            logger.info("Found qkv projection in attention layer")
+
+    # Create input
+    x_input = torch.randn(1, batch_size, seq_len, dim, dtype=torch.bfloat16)
+
+    # Reference forward - the diffusers Attention layer expects specific input format
+    # It typically expects: (hidden_states, encoder_hidden_states=None, ...)
+    with torch.no_grad():
+        try:
+            # Try calling the attention layer directly with the input
+            # Diffusers Attention usually expects (batch, seq_len, hidden_dim)
+            ref_output = reference_model(x_input.squeeze(0))
+            logger.info(f"Reference forward successful. Output shape: {ref_output.shape}")
+        except Exception as e:
+            logger.warning(f"Direct forward failed: {e}")
+            logger.info(
+                f"Attention layer forward signature might be different. Trying with encoder_hidden_states=None..."
+            )
+            try:
+                # Some attention layers need encoder_hidden_states parameter
+                ref_output = reference_model(x_input.squeeze(0), encoder_hidden_states=None)
+                logger.info(
+                    f"Reference forward successful with encoder_hidden_states=None. Output shape: {ref_output.shape}"
+                )
+            except Exception as e2:
+                logger.warning(f"Forward with encoder_hidden_states=None also failed: {e2}")
+                logger.info("Skipping reference forward for now")
+                ref_output = None
+
+    # TTNN forward
+    tt_x_input = ttnn.from_torch(x_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = tt_model(tt_x_input, seq_len)
+
+    # Convert back and compare
+    tt_output_torch = ttnn.to_torch(tt_output)[0, :batch_size, :seq_len, :dim]
+
+    if ref_output is not None:
+        passing, pcc = comp_pcc(ref_output, tt_output_torch, 0.99)
+        logger.info(f"Self-Attention PCC: {pcc}")
+        assert passing, f"PCC check failed: {pcc}"
+    else:
+        logger.warning("Skipping PCC check as reference forward was not successful")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
@@ -8,7 +8,6 @@ Test file for SD3Transformer2DModel with real weights
 import pytest
 import torch
 import ttnn
-from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -169,7 +168,4 @@ def test_sd3_transformer_real_weights(device, reset_seeds):
     pcc_threshold = 0.99
     passing, pcc = assert_with_pcc(ref_proj, tt_proj_torch, pcc=pcc_threshold)
 
-    if passing:
-        logger.info(f"✓ SD3Transformer2DModel PCC: {pcc:.6f}")
-    else:
-        pytest.fail(f"SD3Transformer2DModel PCC test FAILED: pcc={pcc:.6f}")
+    assert passing, f"PCC check failed: {pcc}"

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test file for SD3Transformer2DModel with real weights
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+# Import the transformer model
+from models.experimental.tt_dit.models.transformers.sd35_med.transformer_sd35_medium import SD3Transformer2DModel
+from diffusers.models.transformers.transformer_sd3 import SD3Transformer2DModel as DiffusersSD3Transformer2DModel
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_sd3_transformer_real_weights(device, reset_seeds):
+    """
+    Test SD3Transformer2DModel with real weights from SD3.5 Medium.
+    """
+    # Model configuration for SD3.5 Medium
+    sample_size = 128
+    patch_size = 2
+    in_channels = 16
+    num_layers = 24
+    attention_head_dim = 64
+    num_attention_heads = 24
+    joint_attention_dim = 4096
+    caption_projection_dim = 2432
+    pooled_projection_dim = 2048
+    out_channels = 16
+    pos_embed_max_size = 192
+
+    # Input dimensions
+    batch_size = 1
+    height = sample_size
+    width = sample_size
+    seq_len = (height * width) // (patch_size * patch_size)
+    context_seq_len = 77
+
+    # Create the transformer model
+    model = SD3Transformer2DModel(
+        sample_size=sample_size,
+        patch_size=patch_size,
+        in_channels=in_channels,
+        num_layers=num_layers,
+        attention_head_dim=attention_head_dim,
+        num_attention_heads=num_attention_heads,
+        joint_attention_dim=joint_attention_dim,
+        caption_projection_dim=caption_projection_dim,
+        pooled_projection_dim=pooled_projection_dim,
+        out_channels=out_channels,
+        pos_embed_max_size=pos_embed_max_size,
+        mesh_device=device,
+    )
+
+    # Load real weights from SD3.5 Medium model via HuggingFace
+    model_id = "stabilityai/stable-diffusion-3.5-medium"
+    torch_model = DiffusersSD3Transformer2DModel.from_pretrained(
+        model_id,
+        subfolder="transformer",
+        torch_dtype=torch.bfloat16,
+    )
+    torch_model.eval()
+    full_state_dict = torch_model.state_dict()
+
+    # Load weights into TTNN model
+    model.load_torch_state_dict(full_state_dict)
+
+    # Create test inputs
+    torch.manual_seed(0)
+
+    # Hidden states: NCHW for Diffusers, NHWC for TTNN
+    torch_hidden_states_nchw = torch.randn((batch_size, in_channels, height, width), dtype=torch.bfloat16)
+    torch_hidden_states = torch_hidden_states_nchw.permute(0, 2, 3, 1)  # NCHW -> NHWC
+
+    # Encoder hidden states: [batch, seq_len, features]
+    torch_encoder_hidden_states = torch.randn((batch_size, context_seq_len, joint_attention_dim), dtype=torch.bfloat16)
+
+    # Timestep: [batch]
+    torch_timestep = torch.full((batch_size,), 500.0, dtype=torch.bfloat16)
+
+    # Pooled projection: [batch, features]
+    torch_pooled_projection = torch.randn((batch_size, pooled_projection_dim), dtype=torch.bfloat16)
+
+    # Convert to TTNN tensors
+    hidden_states = ttnn.from_torch(
+        torch_hidden_states,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    encoder_hidden_states = ttnn.from_torch(
+        torch_encoder_hidden_states,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    timestep = ttnn.from_torch(
+        torch_timestep.unsqueeze(-1),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    pooled_projection = ttnn.from_torch(
+        torch_pooled_projection.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Run reference model (step by step to get proj_out before unpatchify)
+    with torch.no_grad():
+        ref_hidden = torch_model.pos_embed(torch_hidden_states_nchw)
+        ref_temb = torch_model.time_text_embed(torch_timestep, torch_pooled_projection)
+        ref_ctx = torch_model.context_embedder(torch_encoder_hidden_states)
+
+        for ref_block in torch_model.transformer_blocks:
+            result = ref_block(hidden_states=ref_hidden, encoder_hidden_states=ref_ctx, temb=ref_temb)
+            if isinstance(result, tuple):
+                ref_ctx, ref_hidden = result
+            else:
+                ref_hidden = result
+
+        ref_normed = torch_model.norm_out(ref_hidden, ref_temb)
+        ref_proj = torch_model.proj_out(ref_normed)
+
+    # Run TTNN model
+    tt_hidden = model.pos_embed(hidden_states)
+    tt_temb = model.time_text_embed(timestep, pooled_projection)
+    tt_ctx = model.context_embedder(encoder_hidden_states)
+
+    if len(tt_hidden.shape) == 3:
+        tt_hidden = ttnn.reshape(tt_hidden, (1, tt_hidden.shape[0], tt_hidden.shape[1], tt_hidden.shape[2]))
+    if len(tt_ctx.shape) == 3:
+        tt_ctx = ttnn.reshape(tt_ctx, (1, tt_ctx.shape[0], tt_ctx.shape[1], tt_ctx.shape[2]))
+
+    for tt_block in model.transformer_blocks:
+        tt_hidden, tt_ctx = tt_block(
+            x=tt_hidden,
+            context=tt_ctx,
+            conditioning=tt_temb,
+            seq_len=seq_len,
+            context_seq_len=context_seq_len,
+        )
+
+    tt_normed = model.norm_out(tt_hidden, tt_temb)
+    tt_proj = model.proj_out(tt_normed)
+
+    # Convert to torch and match shape
+    tt_proj_torch = ttnn.to_torch(ttnn.from_device(tt_proj))
+    while tt_proj_torch.dim() > ref_proj.dim():
+        tt_proj_torch = tt_proj_torch.squeeze(0)
+    while tt_proj_torch.dim() < ref_proj.dim():
+        tt_proj_torch = tt_proj_torch.unsqueeze(0)
+
+    # Final PCC comparison
+    pcc_threshold = 0.99
+    passing, pcc = assert_with_pcc(ref_proj, tt_proj_torch, pcc=pcc_threshold)
+
+    if passing:
+        logger.info(f"✓ SD3Transformer2DModel PCC: {pcc:.6f}")
+    else:
+        pytest.fail(f"SD3Transformer2DModel PCC test FAILED: pcc={pcc:.6f}")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -120,7 +120,7 @@ def test_sd3_transformer_real_weights(device, reset_seeds):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # Run reference model (step by step to get proj_out before unpatchify)
+    # Run reference model
     with torch.no_grad():
         ref_hidden = torch_model.pos_embed(torch_hidden_states_nchw)
         ref_temb = torch_model.time_text_embed(torch_timestep, torch_pooled_projection)

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py
@@ -21,7 +21,7 @@ def get_expected_metrics(mesh_device):
     if tuple(mesh_device.shape) == (1, 1):
         return {
             "clip_encoding_time": 0.5,
-            "t5_encoding_time": 0.001,  # Allow small tolerance for disabled T5 overhead
+            "t5_encoding_time": 0.001,
             "total_encoding_time": 0.5,
             "denoising_steps_time": 200.0,
             "vae_decoding_time": 100.0,
@@ -30,7 +30,7 @@ def get_expected_metrics(mesh_device):
     elif tuple(mesh_device.shape) == (1, 2):
         return {
             "clip_encoding_time": 0.6,
-            "t5_encoding_time": 0.001,  # Allow small tolerance for disabled T5 overhead
+            "t5_encoding_time": 0.001,
             "total_encoding_time": 0.6,
             "denoising_steps_time": 110.0,
             "vae_decoding_time": 90.0,
@@ -48,24 +48,32 @@ def get_expected_metrics(mesh_device):
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, cfg, sp, tp, topology, num_links",
+    "mesh_device, cfg, sp, tp, topology, num_links, device_params",
     [
-        [(1, 1), (1, 0), (1, 0), (1, 0), ttnn.Topology.Linear, 1],
-        [(1, 2), (2, 1), (1, 0), (1, 0), ttnn.Topology.Linear, 1],
+        [
+            (1, 1),
+            (1, 0),
+            (1, 0),
+            (1, 0),
+            ttnn.Topology.Linear,
+            1,
+            {"fabric_config": ttnn.FabricConfig.DISABLED, "l1_small_size": 32768, "trace_region_size": 25000000},
+        ],
+        [
+            (1, 2),
+            (2, 1),
+            (1, 0),
+            (1, 0),
+            ttnn.Topology.Linear,
+            1,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 25000000},
+        ],
     ],
     ids=[
         "1x1_n150",
         "1x2_n300",
     ],
-    indirect=["mesh_device"],
-)
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        {"fabric_config": ttnn.FabricConfig.DISABLED, "l1_small_size": 32768, "trace_region_size": 25000000},
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 25000000},
-    ],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
 def test_sd35_medium_pipeline_performance(
     *,

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_performance_sd35_medium.py
@@ -1,0 +1,385 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import statistics
+from datetime import datetime, timedelta
+
+import pytz
+import pytest
+import ttnn
+from loguru import logger
+from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
+
+from models.experimental.tt_dit.pipelines.stable_diffusion_35_medium.pipeline_stable_diffusion_35_medium import (
+    StableDiffusion3MediumPipeline,
+    TimingCollector,
+)
+
+
+def get_expected_metrics(mesh_device):
+    if tuple(mesh_device.shape) == (1, 1):
+        return {
+            "clip_encoding_time": 0.5,
+            "t5_encoding_time": 0.001,  # Allow small tolerance for disabled T5 overhead
+            "total_encoding_time": 0.5,
+            "denoising_steps_time": 200.0,
+            "vae_decoding_time": 100.0,
+            "total_time": 300.0,
+        }
+    elif tuple(mesh_device.shape) == (1, 2):
+        return {
+            "clip_encoding_time": 0.6,
+            "t5_encoding_time": 0.001,  # Allow small tolerance for disabled T5 overhead
+            "total_encoding_time": 0.6,
+            "denoising_steps_time": 110.0,
+            "vae_decoding_time": 90.0,
+            "total_time": 200.0,
+        }
+    else:
+        assert False, f"Unknown mesh device for performance comparison: {mesh_device}"
+
+
+@pytest.mark.parametrize(
+    "image_w, image_h, guidance_scale, num_inference_steps",
+    [
+        (512, 512, 7.0, 40),
+        (1024, 1024, 7.0, 40),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device, cfg, sp, tp, topology, num_links",
+    [
+        [(1, 1), (1, 0), (1, 0), (1, 0), ttnn.Topology.Linear, 1],
+        [(1, 2), (2, 1), (1, 0), (1, 0), ttnn.Topology.Linear, 1],
+    ],
+    ids=[
+        "1x1_n150",
+        "1x2_n300",
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": ttnn.FabricConfig.DISABLED, "l1_small_size": 32768, "trace_region_size": 25000000},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 25000000},
+    ],
+    indirect=True,
+)
+def test_sd35_medium_pipeline_performance(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    image_w,
+    image_h,
+    guidance_scale,
+    num_inference_steps,
+    cfg,
+    sp,
+    tp,
+    topology,
+    num_links,
+    device_params,
+    model_location_generator,
+    is_ci_env,
+) -> None:
+    """Performance test for SD3.5 Medium pipeline with detailed timing analysis."""
+
+    # Skip FABRIC_1D for single device (1,1) mesh as fabric requires multiple devices
+    if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_1D and tuple(mesh_device.shape) == (1, 1):
+        pytest.skip("FABRIC_1D requires multiple devices, skipping for (1,1) mesh")
+
+    benchmark_profiler = BenchmarkProfiler()
+
+    logger.info(f"  Image size: {image_w}x{image_h}")
+    logger.info(f"  Guidance scale: {guidance_scale}")
+    logger.info(f"  Inference steps: {num_inference_steps}")
+
+    pipeline = StableDiffusion3MediumPipeline.create_pipeline(
+        mesh_device=mesh_device,
+        batch_size=1,
+        image_w=image_w,
+        image_h=image_h,
+        guidance_scale=guidance_scale,
+        cfg_config=cfg,
+        sp_config=sp,
+        tp_config=tp,
+        num_links=num_links,
+        model_checkpoint_path=model_location_generator(
+            "stabilityai/stable-diffusion-3.5-medium", model_subdir="StableDiffusion_35_Medium"
+        ),
+    )
+
+    # Set up timing collector for performance measurement
+    pipeline.timing_collector = TimingCollector()
+
+    # Test prompts - diverse set for comprehensive performance testing
+    prompts = [
+        """A neon-lit alley in a sprawling cyberpunk metropolis at night, rain-slick streets reflecting glowing holograms, dense atmosphere, flying cars in the sky, people in high-tech streetwear — ultra-detailed, cinematic lighting, 4K""",
+        """A colossal whale floating through a desert sky like a blimp, casting a long shadow over sand dunes, people in ancient robes watching in awe, golden hour lighting, dreamlike color palette — surrealism, concept art, Greg Rutkowski style""",
+        """A Roman general standing on a battlefield at dawn, torn red cape blowing in the wind, distant soldiers forming ranks, painterly brushwork in the style of Caravaggio, chiaroscuro lighting, epic composition""",
+        """A tiny, fluffy dragon curled up in a teacup, warm cozy lighting, big expressive eyes, intricate scale patterns, surrounded by books and potions — high detail, Studio Ghibli meets Pixar""",
+        """An epic, high-definition cinematic shot of a rustic snowy cabin glowing warmly at dusk, nestled in a serene winter landscape. Surrounded by gentle snow-covered pines and delicate falling snowflakes — captured in a rich, atmospheric, wide-angle scene with deep cinematic depth and warmth.""",
+    ]
+    negative_prompt = "blurry image"
+
+    # Warmup run
+    logger.info("Running warmup iteration...")
+    pipeline.timing_collector = TimingCollector()
+
+    images = pipeline.run_single_prompt(
+        prompt=prompts[0],
+        negative_prompt=negative_prompt,
+        num_inference_steps=num_inference_steps,
+        seed=0,
+    )
+    images[0].save(f"sd35_medium_{image_w}_{image_h}_warmup.png")
+
+    warmup_timing = pipeline.timing_collector.get_timing_data()
+    logger.info(f"Warmup completed in {warmup_timing.total_time:.2f}s")
+
+    # Performance measurement runs
+    logger.info("Running performance measurement iterations...")
+    num_perf_runs = 4  # Use 4 different prompts for performance testing
+
+    # Optional Tracy profiling (if available)
+    profiler = None
+    try:
+        from tracy import Profiler
+
+        profiler = Profiler()
+        profiler.enable()
+        logger.info("Tracy profiling enabled")
+    except ImportError:
+        logger.info("Tracy profiler not available, continuing without profiling")
+
+    try:
+        for i in range(num_perf_runs):
+            logger.info(f"Performance run {i+1}/{num_perf_runs}...")
+
+            # Reset timing collector for this run
+            pipeline.timing_collector = TimingCollector()
+
+            # Run pipeline with different prompt
+            prompt_idx = (i + 1) % len(prompts)
+
+            # Record total run time
+            benchmark_profiler.start("run", i)
+            images = pipeline.run_single_prompt(
+                prompt=prompts[prompt_idx],
+                negative_prompt=negative_prompt,
+                num_inference_steps=num_inference_steps,
+                seed=0,
+            )
+            benchmark_profiler.end("run", i)
+            images[0].save(f"sd35_medium_{image_w}_{image_h}_perf_run{i}.png")
+
+            # Collect timing data from pipeline's timing_collector
+            timing_data = pipeline.timing_collector.get_timing_data()
+
+            # Manually record timing data into benchmark_profiler by simulating start/end
+            # We use the timing_data to set start/end times for each step
+            base_time = datetime.now(tz=pytz.UTC)
+
+            # Record encoding times
+            benchmark_profiler.start_times[(i, "clip_encoding")] = base_time
+            benchmark_profiler.end_times[(i, "clip_encoding")] = base_time + timedelta(
+                seconds=timing_data.clip_encoding_time
+            )
+
+            benchmark_profiler.start_times[(i, "t5_encoding")] = base_time
+            benchmark_profiler.end_times[(i, "t5_encoding")] = base_time + timedelta(
+                seconds=timing_data.t5_encoding_time
+            )
+
+            benchmark_profiler.start_times[(i, "total_encoding")] = base_time
+            benchmark_profiler.end_times[(i, "total_encoding")] = base_time + timedelta(
+                seconds=timing_data.total_encoding_time
+            )
+
+            benchmark_profiler.start_times[(i, "vae_decoding")] = base_time
+            benchmark_profiler.end_times[(i, "vae_decoding")] = base_time + timedelta(
+                seconds=timing_data.vae_decoding_time
+            )
+
+            # Record individual denoising step times
+            for step_idx, step_time in enumerate(timing_data.denoising_step_times):
+                benchmark_profiler.start_times[(i, f"denoising_step_{step_idx}")] = base_time
+                benchmark_profiler.end_times[(i, f"denoising_step_{step_idx}")] = base_time + timedelta(
+                    seconds=step_time
+                )
+
+            # Collect timing data
+            logger.info(f"  Run {i+1} completed in {timing_data.total_time:.2f}s")
+
+    finally:
+        if profiler:
+            profiler.disable()
+            logger.info("Tracy profiling disabled")
+
+    # Calculate statistics
+    clip_times = [benchmark_profiler.get_duration("clip_encoding", i) for i in range(num_perf_runs)]
+    t5_times = [benchmark_profiler.get_duration("t5_encoding", i) for i in range(num_perf_runs)]
+    total_encoding_times = [benchmark_profiler.get_duration("total_encoding", i) for i in range(num_perf_runs)]
+    vae_times = [benchmark_profiler.get_duration("vae_decoding", i) for i in range(num_perf_runs)]
+    total_times = [benchmark_profiler.get_duration("run", i) for i in range(num_perf_runs)]
+
+    # Calculate per-step denoising times
+    all_denoising_steps = []
+    for i in range(num_perf_runs):
+        for j in range(num_inference_steps):
+            assert benchmark_profiler.contains_step(
+                f"denoising_step_{j}", i
+            ), f"All runs should have {num_inference_steps} denoising steps"
+            all_denoising_steps.append(benchmark_profiler.get_duration(f"denoising_step_{j}", i))
+
+    # Report results
+    cfg_factor = pipeline.dit_parallel_config.cfg_parallel.factor
+    sp_factor = pipeline.dit_parallel_config.sequence_parallel.factor
+    tp_factor = pipeline.dit_parallel_config.tensor_parallel.factor
+    enable_t5_text_encoder = pipeline.t5_enabled()
+
+    print("\n" + "=" * 80)
+    print("STABLE DIFFUSION 3.5 MEDIUM PIPELINE PERFORMANCE RESULTS")
+    print("=" * 80)
+    print(f"Image Size: {image_w}x{image_h}")
+    print(f"Guidance Scale: {guidance_scale}")
+    print(f"Inference Steps: {num_inference_steps}")
+    print(f"Configuration: cfg={cfg_factor}, sp={sp_factor}, tp={tp_factor}")
+    print(f"T5 Text Encoder: {'Enabled' if enable_t5_text_encoder else 'Disabled'}")
+    print(f"Mesh Shape: {mesh_device.shape}")
+    print(f"Topology: {topology}")
+    print("-" * 80)
+
+    def print_stats(name, times):
+        if not times:
+            print(f"{name:25} | No data available")
+            return
+        mean_time = statistics.mean(times)
+        std_time = statistics.stdev(times) if len(times) > 1 else 0
+        min_time = min(times)
+        max_time = max(times)
+        print(
+            f"{name:25} | Mean: {mean_time:8.4f}s | Std: {std_time:8.4f}s | Min: {min_time:8.4f}s | Max: {max_time:8.4f}s"
+        )
+
+    print_stats("CLIP Encoding", clip_times)
+    print_stats("T5 Encoding", t5_times)
+    print_stats("Total Encoding", total_encoding_times)
+    print_stats("Denoising (per step)", all_denoising_steps)
+    print_stats("VAE Decoding", vae_times)
+    print_stats("Total Pipeline", total_times)
+
+    print("-" * 80)
+
+    # Additional metrics
+    if total_times and all_denoising_steps:
+        avg_total_time = statistics.mean(total_times)
+        avg_step_time = statistics.mean(all_denoising_steps)
+        total_denoising_time = avg_step_time * num_inference_steps
+
+        print(f"Average total denoising time: {total_denoising_time:.4f}s")
+        print(f"Denoising throughput: {num_inference_steps / total_denoising_time:.2f} steps/second")
+        print(f"Overall throughput: {1 / avg_total_time:.4f} images/second")
+
+        # Breakdown percentages
+        avg_encoding_time = statistics.mean(total_encoding_times)
+        avg_vae_time = statistics.mean(vae_times)
+
+        print(f"\nTime breakdown:")
+        print(f"  Encoding: {avg_encoding_time/avg_total_time*100:.1f}%")
+        print(f"  Denoising: {total_denoising_time/avg_total_time*100:.1f}%")
+        print(f"  VAE: {avg_vae_time/avg_total_time*100:.1f}%")
+
+        # Performance benchmarks (set reasonable targets)
+        print(f"\nPerformance Analysis:")
+        if avg_total_time < 120:  # Less than 2 minutes for 512x512
+            print(f"  ✅ Excellent performance: {avg_total_time:.1f}s per image")
+        elif avg_total_time < 240:  # Less than 4 minutes
+            print(f"  ✅ Good performance: {avg_total_time:.1f}s per image")
+        elif avg_total_time < 360:  # Less than 6 minutes
+            print(f"  ⚠️  Acceptable performance: {avg_total_time:.1f}s per image")
+        else:
+            print(f"  ❌ Performance may need optimization: {avg_total_time:.1f}s per image")
+
+        # Memory and efficiency notes
+        print(f"\nConfiguration Notes:")
+        print(f"  Parallel Efficiency: {cfg_factor}x CFG, {sp_factor}x SP, {tp_factor}x TP")
+        print(f"  Expected Speedup: ~{cfg_factor * max(sp_factor, tp_factor):.1f}x theoretical")
+        if enable_t5_text_encoder:
+            print(f"  T5 Text Encoder: Enabled (higher quality, slower encoding)")
+        else:
+            print(f"  T5 Text Encoder: Disabled (faster encoding, may affect quality)")
+
+    print("=" * 80)
+
+    # Validate performance
+    measurements = {
+        "clip_encoding_time": statistics.mean(clip_times) if clip_times else 0.0,
+        "t5_encoding_time": statistics.mean(t5_times) if t5_times else 0.0,
+        "total_encoding_time": statistics.mean(total_encoding_times) if total_encoding_times else 0.0,
+        "denoising_steps_time": total_denoising_time,
+        "vae_decoding_time": statistics.mean(vae_times) if vae_times else 0.0,
+        "total_time": statistics.mean(total_times) if total_times else 0.0,
+    }
+
+    expected_metrics = get_expected_metrics(mesh_device)
+    if is_ci_env:
+        # In CI, dump a performance report
+        benchmark_data = BenchmarkData()
+        for iteration in range(num_perf_runs):
+            for step_name, target in zip(
+                ["total_encoding", "denoising", "vae_decoding", "run"],
+                [
+                    expected_metrics["total_encoding_time"],
+                    expected_metrics["denoising_steps_time"],
+                    expected_metrics["vae_decoding_time"],
+                    expected_metrics["total_time"],
+                ],
+            ):
+                benchmark_data.add_measurement(
+                    profiler=benchmark_profiler,
+                    iteration=iteration,
+                    step_name=step_name,
+                    name=step_name,
+                    value=benchmark_profiler.get_duration(step_name, iteration),
+                    target=target,
+                )
+        device_name_map = {
+            (1, 1): "WH_N150",
+            (1, 2): "WH_N300",
+        }
+        benchmark_data.save_partial_run_json(
+            benchmark_profiler,
+            run_type=device_name_map[tuple(mesh_device.shape)],
+            ml_model_name="SD35_Medium",
+            batch_size=1,
+            config_params={
+                "width": image_w,
+                "height": image_h,
+                "num_frames": 1,
+                "num_steps": num_inference_steps,
+                "sp_factor": sp_factor,
+                "tp_factor": tp_factor,
+                "topology": str(topology),
+                "num_links": num_links,
+                "fsdp": False,
+            },
+        )
+
+    pass_perf_check = True
+    assert_msgs = []
+    for k in expected_metrics.keys():
+        if measurements[k] > expected_metrics[k]:
+            assert_msgs.append(
+                f"Warning: {k} is outside of the tolerance range. Expected: {expected_metrics[k]}, Actual: {measurements[k]}"
+            )
+            pass_perf_check = False
+
+    assert pass_perf_check, "\n".join(assert_msgs)
+
+    # Synchronize all devices
+    for submesh_device in pipeline.submesh_devices:
+        ttnn.synchronize_device(submesh_device)
+
+    logger.info("Performance test completed successfully!")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
@@ -1,14 +1,14 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
 import ttnn
 from loguru import logger
 
-from ....pipelines.stable_diffusion_35_medium.pipeline_stable_diffusion_35_medium import (
+from models.experimental.tt_dit.pipelines.stable_diffusion_35_medium.pipeline_stable_diffusion_35_medium import (
     StableDiffusion3MediumPipeline as TTSD35MediumPipeline,
 )
-from ....parallel.config import DiTParallelConfig, ParallelFactor
+from models.experimental.tt_dit.parallel.config import DiTParallelConfig, ParallelFactor
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,6 @@ def test_sd35_medium_pipeline_functional(
     num_links: int,
 ) -> None:
     """Functional test for SD3.5 Medium pipeline on N300 with CFG enabled."""
-
     parallel_config = DiTParallelConfig(
         cfg_parallel=ParallelFactor(factor=2, mesh_axis=1),  # CFG parallel on axis 1 for N300
         tensor_parallel=ParallelFactor(factor=1, mesh_axis=tp_axis),
@@ -82,12 +81,4 @@ def test_sd35_medium_pipeline_functional(
     # Save TT test image for visual inspection
     images[0].save("test_sd35_medium_tt_output.png")
     logger.info("TT image saved to test_sd35_medium_tt_output.png")
-
-    # Skip Diffusers reference generation (too slow on CPU without GPU)
-    # To generate Diffusers reference, run separately on a GPU machine:
-    # ```
-    # from diffusers import StableDiffusion3Pipeline
-    # pipe = StableDiffusion3Pipeline.from_pretrained("stabilityai/stable-diffusion-3.5-medium", torch_dtype=torch.bfloat16).to("cuda")
-    # pipe(prompt="a cat with a hat and pink nose", num_inference_steps=28, height=512, width=512, guidance_scale=4.5, generator=torch.Generator().manual_seed(123)).images[0].save("diffusers_ref.png")
-    # ```
     logger.info("TT image generation complete. Check test_sd35_medium_tt_output.png")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
 import pytest
 import ttnn
 from loguru import logger
@@ -9,6 +11,36 @@ from models.experimental.tt_dit.pipelines.stable_diffusion_35_medium.pipeline_st
     StableDiffusion3MediumPipeline as TTSD35MediumPipeline,
 )
 from models.experimental.tt_dit.parallel.config import DiTParallelConfig, ParallelFactor
+
+
+def _get_prompt_from_terminal(default_prompt: str) -> str:
+    """Get prompt from command line arguments or environment variable."""
+    if "--prompt" in sys.argv:
+        idx = sys.argv.index("--prompt")
+        if idx + 1 < len(sys.argv):
+            return sys.argv[idx + 1]
+
+    env_prompt = os.getenv("PROMPT")
+    if env_prompt:
+        return env_prompt
+
+    return default_prompt
+
+
+def _get_negative_prompt_from_terminal(default_negative_prompt: str) -> str:
+    """Get negative prompt from command line arguments or environment variable."""
+    # Check command line arguments for --negative-prompt flag
+    if "--negative-prompt" in sys.argv:
+        idx = sys.argv.index("--negative-prompt")
+        if idx + 1 < len(sys.argv):
+            return sys.argv[idx + 1]
+
+    # Check environment variable
+    env_negative_prompt = os.getenv("NEGATIVE_PROMPT")
+    if env_negative_prompt:
+        return env_negative_prompt
+
+    return default_negative_prompt
 
 
 @pytest.mark.parametrize(
@@ -61,15 +93,12 @@ def test_sd35_medium_pipeline_functional(
         sequence_parallel=ParallelFactor(factor=1, mesh_axis=sp_axis),
     )
 
-    # Test with a simple prompt
-    prompt = "A capybara wearing a suit holding a sign that reads hello world"
+    prompt = _get_prompt_from_terminal("A capybara wearing a suit holding a sign that reads hello world")
+    negative_prompt = _get_negative_prompt_from_terminal("blurry image")
     seed = 23
     num_steps = 40
 
-    # guidance_cond: 2 for CFG (positive + negative prompts), 1 for no CFG
-    # For N150 (cfg_factor=1): guidance_cond=2 (process both prompts on same device)
-    # For N300 (cfg_factor=2): guidance_cond=2 (CFG parallel across devices)
-    guidance_cond = 2 if cfg_factor == 1 else cfg_factor
+    guidance_cond = 2
 
     tt_pipe = TTSD35MediumPipeline(
         mesh_device=mesh_device,
@@ -96,7 +125,7 @@ def test_sd35_medium_pipeline_functional(
 
     images = tt_pipe.run_single_prompt(
         prompt=prompt,
-        negative_prompt="blurry image",
+        negative_prompt=negative_prompt,
         num_inference_steps=num_steps,
         seed=seed,
     )
@@ -106,5 +135,5 @@ def test_sd35_medium_pipeline_functional(
         image_size,
         image_size,
     ), f"Image size should be {image_size}x{image_size}, got {images[0].size}"
-    images[0].save(f"test_sd35_medium_tt_output_{image_size}.png")
-    logger.info(f"TT {image_size}x{image_size} image saved to test_sd35_medium_tt_output_{image_size}.png")
+    images[0].save(f"sd35_medium_tt_output_{image_size}x{image_size}.png")
+    logger.info(f"TT {image_size}x{image_size} image saved to sd35_medium_tt_output_{image_size}x{image_size}.png")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
@@ -63,9 +63,8 @@ def test_sd35_medium_pipeline_functional(
     )
 
     # Test with a simple prompt
-    # prompt = "A capybara wearing a suit holding a sign that reads hello world"
-    prompt = "a snowman wearing red scarf and sunglasses"
-    seed = 123
+    prompt = "A capybara wearing a suit holding a sign that reads hello world"
+    seed = 23
     num_steps = 40
 
     images = tt_pipe.run_single_prompt(

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
@@ -22,12 +22,22 @@ from models.experimental.tt_dit.parallel.config import DiTParallelConfig, Parall
 @pytest.mark.parametrize(
     "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768}], indirect=True
 )
+@pytest.mark.parametrize(
+    "image_size, spatial_sequence_length",
+    [
+        (512, 1024),
+        (1024, 4096),
+    ],
+    ids=["512x512", "1024x1024"],
+)
 def test_sd35_medium_pipeline_functional(
     *,
     mesh_device: ttnn.MeshDevice,
     sp_axis: int,
     tp_axis: int,
     num_links: int,
+    image_size: int,
+    spatial_sequence_length: int,
 ) -> None:
     """Functional test for SD3.5 Medium pipeline on N300 with CFG enabled."""
     parallel_config = DiTParallelConfig(
@@ -36,49 +46,45 @@ def test_sd35_medium_pipeline_functional(
         sequence_parallel=ParallelFactor(factor=1, mesh_axis=sp_axis),
     )
 
-    # Create pipeline with N300 CFG configuration
+    # Test with a simple prompt
+    prompt = "A capybara wearing a suit holding a sign that reads hello world"
+    seed = 23
+    num_steps = 40
+
     tt_pipe = TTSD35MediumPipeline(
         mesh_device=mesh_device,
         enable_t5_text_encoder=False,
         guidance_cond=2,  # CFG enabled: positive + negative prompt
         parallel_config=parallel_config,
         num_links=num_links,
-        height=512,  # Smaller image for faster test
-        width=512,
+        height=image_size,
+        width=image_size,
         model_checkpoint_path="stabilityai/stable-diffusion-3.5-medium",
         use_cache=False,
     )
 
-    # Prepare with guidance_scale=4.5 for CFG on N300
     tt_pipe.prepare(
         batch_size=1,
         num_images_per_prompt=1,
-        width=512,
-        height=512,
-        guidance_scale=7,  # CFG enabled with guidance scale 4.5
+        width=image_size,
+        height=image_size,
+        guidance_scale=7,
         max_t5_sequence_length=256,
         prompt_sequence_length=333,
-        spatial_sequence_length=1024,
+        spatial_sequence_length=spatial_sequence_length,
     )
-
-    # Test with a simple prompt
-    prompt = "A capybara wearing a suit holding a sign that reads hello world"
-    seed = 23
-    num_steps = 40
 
     images = tt_pipe.run_single_prompt(
         prompt=prompt,
-        negative_prompt=" ",
-        # negative_prompt="blurry, low quality, low contrast",
+        negative_prompt="blurry image",
         num_inference_steps=num_steps,
         seed=seed,
     )
 
-    # Basic validation
     assert len(images) == 1, "Should generate exactly one image"
-    assert images[0].size == (512, 512), f"Image size should be 512x512, got {images[0].size}"
-
-    # Save TT test image for visual inspection
-    images[0].save("test_sd35_medium_tt_output.png")
-    logger.info("TT image saved to test_sd35_medium_tt_output.png")
-    logger.info("TT image generation complete. Check test_sd35_medium_tt_output.png")
+    assert images[0].size == (
+        image_size,
+        image_size,
+    ), f"Image size should be {image_size}x{image_size}, got {images[0].size}"
+    images[0].save(f"test_sd35_medium_tt_output_{image_size}.png")
+    logger.info(f"TT {image_size}x{image_size} image saved to test_sd35_medium_tt_output_{image_size}.png")

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
@@ -12,15 +12,27 @@ from models.experimental.tt_dit.parallel.config import DiTParallelConfig, Parall
 
 
 @pytest.mark.parametrize(
-    "mesh_device, sp_axis, tp_axis, num_links",
+    "mesh_device, sp_axis, tp_axis, num_links, cfg_factor, device_params",
     [
-        [(1, 2), 0, 1, 1],  # N300 configuration - 2 devices with CFG parallel
+        [
+            (1, 1),
+            0,
+            0,
+            1,
+            1,
+            {"fabric_config": ttnn.FabricConfig.DISABLED, "l1_small_size": 32768},
+        ],  # N150 configuration - 1 device, no CFG parallel, no fabric needed
+        [
+            (1, 2),
+            0,
+            1,
+            1,
+            2,
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768},
+        ],  # N300 configuration - 2 devices with CFG parallel
     ],
-    ids=["1x2_n300"],
-    indirect=["mesh_device"],
-)
-@pytest.mark.parametrize(
-    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768}], indirect=True
+    ids=["1x1_n150", "1x2_n300"],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(
     "image_size, spatial_sequence_length",
@@ -36,12 +48,15 @@ def test_sd35_medium_pipeline_functional(
     sp_axis: int,
     tp_axis: int,
     num_links: int,
+    cfg_factor: int,
     image_size: int,
     spatial_sequence_length: int,
 ) -> None:
-    """Functional test for SD3.5 Medium pipeline on N300 with CFG enabled."""
+    """Functional test for SD3.5 Medium pipeline on N150 and N300."""
+    # CFG parallel: factor=2 for N300 (2 devices), factor=1 for N150 (1 device)
+    cfg_mesh_axis = 1 if cfg_factor > 1 else 0
     parallel_config = DiTParallelConfig(
-        cfg_parallel=ParallelFactor(factor=2, mesh_axis=1),  # CFG parallel on axis 1 for N300
+        cfg_parallel=ParallelFactor(factor=cfg_factor, mesh_axis=cfg_mesh_axis),
         tensor_parallel=ParallelFactor(factor=1, mesh_axis=tp_axis),
         sequence_parallel=ParallelFactor(factor=1, mesh_axis=sp_axis),
     )
@@ -51,10 +66,15 @@ def test_sd35_medium_pipeline_functional(
     seed = 23
     num_steps = 40
 
+    # guidance_cond: 2 for CFG (positive + negative prompts), 1 for no CFG
+    # For N150 (cfg_factor=1): guidance_cond=2 (process both prompts on same device)
+    # For N300 (cfg_factor=2): guidance_cond=2 (CFG parallel across devices)
+    guidance_cond = 2 if cfg_factor == 1 else cfg_factor
+
     tt_pipe = TTSD35MediumPipeline(
         mesh_device=mesh_device,
         enable_t5_text_encoder=False,
-        guidance_cond=2,  # CFG enabled: positive + negative prompt
+        guidance_cond=guidance_cond,
         parallel_config=parallel_config,
         num_links=num_links,
         height=image_size,

--- a/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
+++ b/models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+from loguru import logger
+
+from ....pipelines.stable_diffusion_35_medium.pipeline_stable_diffusion_35_medium import (
+    StableDiffusion3MediumPipeline as TTSD35MediumPipeline,
+)
+from ....parallel.config import DiTParallelConfig, ParallelFactor
+
+
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, num_links",
+    [
+        [(1, 2), 0, 1, 1],  # N300 configuration - 2 devices with CFG parallel
+    ],
+    ids=["1x2_n300"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768}], indirect=True
+)
+def test_sd35_medium_pipeline_functional(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    num_links: int,
+) -> None:
+    """Functional test for SD3.5 Medium pipeline on N300 with CFG enabled."""
+
+    parallel_config = DiTParallelConfig(
+        cfg_parallel=ParallelFactor(factor=2, mesh_axis=1),  # CFG parallel on axis 1 for N300
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=tp_axis),
+        sequence_parallel=ParallelFactor(factor=1, mesh_axis=sp_axis),
+    )
+
+    # Create pipeline with N300 CFG configuration
+    tt_pipe = TTSD35MediumPipeline(
+        mesh_device=mesh_device,
+        enable_t5_text_encoder=False,
+        guidance_cond=2,  # CFG enabled: positive + negative prompt
+        parallel_config=parallel_config,
+        num_links=num_links,
+        height=512,  # Smaller image for faster test
+        width=512,
+        model_checkpoint_path="stabilityai/stable-diffusion-3.5-medium",
+        use_cache=False,
+    )
+
+    # Prepare with guidance_scale=4.5 for CFG on N300
+    tt_pipe.prepare(
+        batch_size=1,
+        num_images_per_prompt=1,
+        width=512,
+        height=512,
+        guidance_scale=7,  # CFG enabled with guidance scale 4.5
+        max_t5_sequence_length=256,
+        prompt_sequence_length=333,
+        spatial_sequence_length=1024,
+    )
+
+    # Test with a simple prompt
+    # prompt = "A capybara wearing a suit holding a sign that reads hello world"
+    prompt = "a snowman wearing red scarf and sunglasses"
+    seed = 123
+    num_steps = 40
+
+    images = tt_pipe.run_single_prompt(
+        prompt=prompt,
+        negative_prompt=" ",
+        # negative_prompt="blurry, low quality, low contrast",
+        num_inference_steps=num_steps,
+        seed=seed,
+    )
+
+    # Basic validation
+    assert len(images) == 1, "Should generate exactly one image"
+    assert images[0].size == (512, 512), f"Image size should be 512x512, got {images[0].size}"
+
+    # Save TT test image for visual inspection
+    images[0].save("test_sd35_medium_tt_output.png")
+    logger.info("TT image saved to test_sd35_medium_tt_output.png")
+
+    # Skip Diffusers reference generation (too slow on CPU without GPU)
+    # To generate Diffusers reference, run separately on a GPU machine:
+    # ```
+    # from diffusers import StableDiffusion3Pipeline
+    # pipe = StableDiffusion3Pipeline.from_pretrained("stabilityai/stable-diffusion-3.5-medium", torch_dtype=torch.bfloat16).to("cuda")
+    # pipe(prompt="a cat with a hat and pink nose", num_inference_steps=28, height=512, width=512, guidance_scale=4.5, generator=torch.Generator().manual_seed(123)).images[0].save("diffusers_ref.png")
+    # ```
+    logger.info("TT image generation complete. Check test_sd35_medium_tt_output.png")


### PR DESCRIPTION

### Problem description

Enable SD3.5-Medium model support on N150/N300 for models/tt_dit

### What's changed

**Pipeline specific files added**

- models/experimental/tt_dit/models/transformers/sd35_med/attention_sd35_medium.py
- models/experimental/tt_dit/models/transformers/sd35_med/joint_block_sd35_medium.py
- models/experimental/tt_dit/models/transformers/sd35_med/transformer_sd35_medium.py
- models/experimental/tt_dit/models/vae/vae_sd35_med.py (Updated the existing vae decoder with ttcnn conv2d)
- models/experimental/tt_dit/pipelines/stable_diffusion_35_medium/pipeline_stable_diffusion_35_medium.py

**Tests added**

- models/experimental/tt_dit/tests/models/sd35_med/test_attention_sd35_medium.py
- models/experimental/tt_dit/tests/models/sd35_med/test_mmdit_sd35_medium.py
- models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py

### How to Run
1. Request access to the model on HuggingFace (required for gated weights):
   https://huggingface.co/stabilityai/stable-diffusion-3.5-medium

2. Authenticate with your HuggingFace token:

```bash
huggingface-cli login
```

3. Activate the repo virtual environment and set `PYTHONPATH`:

```bash
source python_env/bin/activate
export PYTHONPATH=$(pwd)
```

4. Run the SD3.5 Medium pipeline test:
```bash
# Run on N150 (1x1 mesh) at 512x512
pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x1_n150 and 512x512"

# Run on N150 (1x1 mesh) at 1024x1024
pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x1_n150 and 1024x1024"

# Run on N300 (1x2 mesh) at 512x512
pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x2_n300 and 512x512"

# Run on N300 (1x2 mesh) at 1024x1024
pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py -k "1x2_n300 and 1024x1024"

# Using command line arguments
pytest models/experimental/tt_dit/tests/models/sd35_med/test_pipeline_sd35_medium.py --prompt "your custom prompt" --negative-prompt "your negative prompt"
```

### Performance
| Configuration | Image Size | CLIP Encoding | T5 Encoding | Total Encoding | Denoising (per step) | Total Denoising | VAE Decoding | Total Pipeline Runtime | Throughput |
|---------------|------------|---------------|------------|---------------|----------------------|-----------------|--------------|----------------------|------------|
| N150 (1x1 mesh) | 512×512 | ~0.07s | ~0.00s (disabled) | ~0.15s | ~0.60s | ~24.12s | ~0.34s | **~24.63s** | ~0.0406 images/second |
| N150 (1x1 mesh) | 1024×1024 | ~0.06s | ~0.00s (disabled) | ~0.14s | ~2.63s | ~105.23s | ~7.86s | **~113.27s** | ~0.0088 images/second |
| N300 (1x2 mesh) | 512×512 | ~0.07s | ~0.00s (disabled) | ~0.15s | ~0.71s | ~28.31s | ~0.34s | **~28.83s** | ~0.0347 images/second |
| N300 (1x2 mesh) | 1024×1024 | ~0.07s | ~0.00s (disabled) | ~0.15s | ~2.68s | ~107.27s | ~8.06s | **~115.52s** | ~0.0087 images/second |

*All measurements are for 40 inference steps with Guidance Scale=7.0*


**Supported Device: N300,N150
-Supports on N300 (1x2 mesh) at 512×512 and 1024x1024
-Supports on N150 (1x1 mesh) at 512×512 and 1024x1024


**Example prompt and image**

prompt = "A capybara wearing a suit holding a sign that reads hello world"
seed = 23
number of inference steps = 40


output image :
512x512

<img width="512" height="512" alt="test_sd35_medium_tt_output_512" src="https://github.com/user-attachments/assets/491915b5-623d-4e7c-b6a2-beffc8ec6542" />




